### PR TITLE
Phase 3 Gnothi seautom 

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,23 +5,24 @@
 - [x] Filter to tier 1 + follower emotes only
 - [x] Fix stream category injection
 
-## Phase 2: Voice Integration (Done pending live test)
+## Phase 2: Voice Integration (Done ✓)
 - [x] Combined entry point (FastAPI + TwitchIO in one async process)
 - [x] Feed voice transcriptions into conversation context
 - [x] Friendly error handling and clean shutdown
 - [x] Voice-triggered replies with separate voice frequency
 - [x] Name mentions: always trigger from chat, boost to chat rate from voice
-- [ ] Merge to main + linting pass
-- [ ] Dashboard improvements (interleaved chat + transcriptions, prompt window highlighting)
+- [x] Merged to main
 
 ## Phase 3: Code Quality & Resilience
-- [ ] Linting fixes + type hints
-- [ ] Audit log levels — most current logging.info should be logging.debug; INFO reserved for meaningful events (bot ready, response sent, errors)
+- [x] Linting fixes + type hints (black, flake8, mypy all clean)
+- [ ] Audit log levels — most logging.info → logging.debug; INFO reserved for meaningful events only (bot ready, response sent, errors)
+- [ ] Self-knowledge block — faebot should be able to accurately describe faerself, faer architecture, and faer development when asked
 - [ ] Centralize logging config (currently split across local.py, faebot.py, server.py)
 - [ ] Run Whisper transcription in executor (unblock event loop during transcription)
 - [ ] Retry logic for API calls
 - [ ] Graceful shutdown — currently Ctrl+C produces a TwitchIO `WSConnection._task_callback` traceback; fix is to intercept SIGINT before asyncio cancels tasks and shut down bot + uvicorn in sequence
 - [ ] Basic test suite
+- [ ] Dashboard improvements — reassess after log cleanup; clean logs may give sufficient visibility without the architecture investment
 
 ## Phase 4: Database Integration
 - [ ] PostgreSQL setup with asyncpg (port from Discord bot)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,30 +15,41 @@
 
 ## Phase 3: Code Quality & Resilience
 - [x] Linting fixes + type hints (black, flake8, mypy all clean)
-- [ ] Audit log levels — most logging.info → logging.debug; INFO reserved for meaningful events only (bot ready, response sent, errors)
-- [ ] Self-knowledge block — faebot should be able to accurately describe faerself, faer architecture, and faer development when asked
-- [ ] Centralize logging config (currently split across local.py, faebot.py, server.py)
+- [x] Audit log levels — most logging.info → logging.debug; INFO reserved for meaningful events only (bot ready, response sent, errors)
+- [x] Self-knowledge block — faebot can accurately describe faerself, faer architecture, history, and live parameters (model, frequencies, history length)
+- [x] Centralize logging config — local.py owns config (ENVIRONMENT-aware); faebot.py and server.py keep simple INFO fallbacks for standalone use
 - [ ] Run Whisper transcription in executor (unblock event loop during transcription)
 - [ ] Retry logic for API calls
 - [ ] Graceful shutdown — currently Ctrl+C produces a TwitchIO `WSConnection._task_callback` traceback; fix is to intercept SIGINT before asyncio cancels tasks and shut down bot + uvicorn in sequence
-- [ ] Basic test suite
-- [ ] Dashboard improvements — reassess after log cleanup; clean logs may give sufficient visibility without the architecture investment
 
-## Phase 4: Database Integration
+## Phase 4: Architecture Refactor & Dashboard
+The dashboard is blind to generation — can't see what prompt was used or what faebot sent. Fixing this requires splitting `faebot.py` into clean modules first. Full design notes in snippets/architecture-refactor.md (not versioned).
+
+Do these in order — each step is independently shippable and the bot keeps working throughout:
+
+- [ ] Extract `core.py` — move `Conversation`, `conversations`, `generate_response`, `generate`, `choose_to_reply` out of `faebot.py`. No TwitchIO or FastAPI deps in `core`. Both `faebot.py` and `server.py` import from it. This is the prerequisite for everything else.
+- [ ] Test suite — write against `core.py` now that it has no platform deps. Tests act as a contract for the remaining refactor steps.
+- [ ] Add event queue — `core.generate_response` puts events (`generating`, `response`, `error`) on an `asyncio.Queue` injected by `local.py`. Both bot and server share the same queue.
+- [ ] Dashboard event WebSocket — `server.py` gains `/ws/events`; drains the queue and pushes to browser. Dashboard renders: generation indicator, response card with collapsible prompt/system prompt inspector.
+- [ ] Extract `commands.py` — move all `fb;`/`fae;` command handlers to a `FaebotCommands` mixin. `Faebot` inherits from both `commands.Bot` and `FaebotCommands`. `faebot.py` becomes thin event wiring only.
+
+Note: `core.py` is designed to work cleanly with asyncpg (Phase 5) — conversation management is already async and the dataclass is easy to hydrate from DB rows. For cross-platform shared memory (Phase 7), the DB is the right first bridge; the same PostgreSQL instance lets both Twitch and Discord bots share state without needing to share code.
+
+## Phase 5: Database Integration
 - [ ] PostgreSQL setup with asyncpg (port from Discord bot)
 - [ ] Replace permalog.txt with structured DB logging (conversations, transcriptions)
 - [ ] Conversation persistence across restarts
 - [ ] Queryable history for training data collection
 
-## Phase 5: Local Model Generation (KoboldCPP)
+## Phase 6: Local Model Generation (KoboldCPP)
 - [ ] KoboldCPP client on separate machine
 - [ ] Fallback to OpenRouter when local model is unavailable
 - [ ] Per-channel model selection
 
-## Phase 6: Memory System
+## Phase 7: Memory System
 This is a significant sub-project spanning both Twitch and Discord bots.
 
-- [ ] Self-knowledge block — structured description of faebot's architecture, who built faer, how fae works, injected into system prompt so fae can answer questions about faerself accurately
+- [x] Self-knowledge block — done in Phase 3; always-included in system prompt
 - [ ] Research ready-made LLM memory solutions (mem0, MemGPT/Letta, Zep, LangChain memory modules)
 - [ ] Short-term: current chatlog window (already done)
 - [ ] Medium-term: per-user memory (regulars, their interests, past interactions) — requires DB
@@ -46,13 +57,13 @@ This is a significant sub-project spanning both Twitch and Discord bots.
 - [ ] Shared memory layer across Twitch and Discord bots (faebot should know the same people across platforms)
 - [ ] Retrieval strategy: RAG over stored memories vs. summarization vs. hybrid
 
-## Phase 7: Custom Faebot Model
+## Phase 8: Custom Faebot Model
 - [ ] Collect and curate training data (chat logs, voice transcriptions, streamer messages)
 - [ ] Include streamer's own voice/messages so faebot sounds like faer sister
 - [ ] Fine-tune a small base model (Mistral/Llama-class)
 - [ ] Deploy via KoboldCPP, use across both Twitch and Discord bots
 
-## Phase 8: Text-to-Speech
+## Phase 9: Text-to-Speech
 - [ ] Faebot speaks on stream (not just types in chat)
 - [ ] Voice should feel consistent with faebot's personality
 - [ ] Likely after custom model work so voice + personality are coherent

--- a/faebot.py
+++ b/faebot.py
@@ -97,15 +97,21 @@ class Faebot(commands.Bot):
 
     def fix_emote_spacing(self, text: str) -> str:
         """Ensure emotes are surrounded by whitespace so Twitch renders them."""
-        # Build one pattern that matches any emote, longest first to avoid
-        # transf23Flutter matching inside transf23Fluttering
+        if not self.emotes:
+            return text
+        # Split text on emote boundaries, longest first so transf23Fluttering
+        # is matched before transf23Flutter (re.split doesn't backtrack like sub)
         sorted_emotes = sorted(self.emotes, key=len, reverse=True)
         pattern = '(' + '|'.join(re.escape(e) for e in sorted_emotes) + ')'
-        # Insert space before emote if preceded by non-whitespace
-        text = re.sub(rf'(\S){pattern}', r'\1 \2', text)
-        # Insert space after emote if followed by non-whitespace
-        text = re.sub(rf'{pattern}(\S)', r'\1 \2', text)
-        return re.sub(r'  +', ' ', text).strip()
+        parts = re.split(pattern, text)
+        # Pad each emote with spaces, then collapse doubles
+        result = []
+        for part in parts:
+            if part in self.emotes:
+                result.append(f' {part} ')
+            else:
+                result.append(part)
+        return re.sub(r'  +', ' ', ''.join(result)).strip()
 
     def filter_transcription(self, text: str) -> str | None:
         """Filter out known Whisper mistranscriptions. Returns None to skip entirely."""

--- a/faebot.py
+++ b/faebot.py
@@ -102,22 +102,24 @@ class Faebot(commands.Bot):
         # Split text on emote boundaries, longest first so transf23Fluttering
         # is matched before transf23Flutter (re.split doesn't backtrack like sub)
         sorted_emotes = sorted(self.emotes, key=len, reverse=True)
-        pattern = '(' + '|'.join(re.escape(e) for e in sorted_emotes) + ')'
+        pattern = "(" + "|".join(re.escape(e) for e in sorted_emotes) + ")"
         parts = re.split(pattern, text)
         # Pad each emote with spaces, then collapse doubles
         result = []
         for part in parts:
             if part in self.emotes:
-                result.append(f' {part} ')
+                result.append(f" {part} ")
             else:
                 result.append(part)
-        return re.sub(r'  +', ' ', ''.join(result)).strip()
+        return re.sub(r"  +", " ", "".join(result)).strip()
 
     def filter_transcription(self, text: str) -> str | None:
         """Filter out known Whisper mistranscriptions. Returns None to skip entirely."""
         for banned in self.whisper_filter:
             if banned.lower() in text.lower():
-                logging.debug(f"Filtered banned string '{banned}' from transcription: {text}")
+                logging.debug(
+                    f"Filtered banned string '{banned}' from transcription: {text}"
+                )
                 return None
         return text
 
@@ -132,9 +134,10 @@ class Faebot(commands.Bot):
 
     async def handle_transcription(self, channel_name: str, text: str):
         """Handle a voice transcription from the streamer."""
-        text = self.filter_transcription(text)
-        if text is None:
+        filtered = self.filter_transcription(text)
+        if filtered is None:
             return
+        text = filtered
 
         conversation = self.ensure_conversation(channel_name)
         # TODO: apply aliases here — streamer's alias isn't reflected in voice transcriptions

--- a/faebot.py
+++ b/faebot.py
@@ -105,7 +105,7 @@ class Faebot(commands.Bot):
         conversation = self.ensure_conversation(channel_name)
         # TODO: apply aliases here — streamer's alias isn't reflected in voice transcriptions
         conversation.chatlog.append(f"[streamer voice] {channel_name}: {text}")
-        logging.info(f"Voice transcription added to {channel_name}: {text}")
+        logging.debug(f"Voice transcription added to {channel_name}: {text}")
 
         if "faebot" in text.lower():
             logging.info(
@@ -123,7 +123,7 @@ class Faebot(commands.Bot):
         if message.echo:
             return
 
-        logging.info(f"received message: {message.author}: {message.content}")
+        logging.debug(f"received message: {message.author}: {message.content}")
         self.ensure_conversation(message.channel.name)
 
         # command, execute command if appropriate otherwise return out
@@ -156,15 +156,15 @@ class Faebot(commands.Bot):
         conversation = self.conversations[channel_name]
 
         if conversation.silenced:
-            logging.info(f"faebot is silenced in {channel_name}")
+            logging.debug(f"faebot is silenced in {channel_name}")
             return False
 
         if frequency <= 0:
-            logging.info(f"frequency is set to {frequency}, not replying.")
+            logging.debug(f"frequency is set to {frequency}, not replying.")
             return False
 
         if frequency >= 1:
-            logging.info(f"frequency is set to {frequency}, always replying.")
+            logging.debug(f"frequency is set to {frequency}, always replying.")
             return True
 
         roll = random()
@@ -172,7 +172,7 @@ class Faebot(commands.Bot):
             logging.info(f"Rolled {roll:.3f} < {frequency}, generating!")
             return True
         else:
-            logging.info(f"Rolled {roll:.3f} >= {frequency}, not generating.")
+            logging.debug(f"Rolled {roll:.3f} >= {frequency}, not generating.")
             return False
 
     def permalog(self, log_message):
@@ -210,13 +210,13 @@ class Faebot(commands.Bot):
         )
 
         if len(conversation.chatlog) > conversation.history:
-            logging.info(
+            logging.debug(
                 f"message history has exceeded the set history length of {conversation.history}"
             )
             conversation.chatlog = conversation.chatlog[-conversation.history :]
 
         prompt = "\n".join(conversation.chatlog) + "\nfaebot:"
-        logging.info(
+        logging.debug(
             f"model: {conversation.model}\nsystem_prompt: \n{system_prompt}\nprompt: \n{prompt}"
         )
 
@@ -227,7 +227,7 @@ class Faebot(commands.Bot):
             "seed": randrange(1, 1024),
         }
 
-        logging.info(
+        logging.debug(
             f"generating with parameters: \nTemperature:{params['temperature']}\nTop_k:{params['top_k']} \ntop_p: {params['top_p']}\nseed: {params['seed']}"
         )
         current_time = datetime.datetime.now()
@@ -247,7 +247,7 @@ class Faebot(commands.Bot):
             )
             logging.info(f"received response: {response}")
             if len(response) > 499:
-                logging.info("generated content exceeded 500 characters, trimming.")
+                logging.debug("generated content exceeded 500 characters, trimming.")
                 response = response[:499] + "–"
             self.permalog(
                 f"generated message:{response}\n------------------------------------------------------------\n\n"
@@ -255,7 +255,7 @@ class Faebot(commands.Bot):
             await channel.send(response)
 
         except Exception as e:
-            logging.info(
+            logging.error(
                 f"Unknown error has occured, please contact the administrator. Error: {e}"
             )
             response = (

--- a/faebot.py
+++ b/faebot.py
@@ -191,12 +191,22 @@ class Faebot(commands.Bot):
         game_name = channel_info.game_name if channel_info else "Unknown"
 
         system_prompt = (
-            f"I'm an AI chatbot called faebot. \n"
-            f"I'm hanging out in {channel_name}'s chat on twitch where I enjoy talking with chatters about whatever the streamer, {channel_name}, is doing. "
-            f"The streamer is playing {game_name} and the title is {stream_title}\n"
-            f"I am friendly and talkative. I like to use the channel emotes to express myself they are {self.emotes},"
-            f"my favourite is transf23Botlove since it's a picture of me! \n"
-            "I make sure my messages are below the character limit of 500 characters. I prioritize replying to the last message and I never ask followup questions."
+            "I'm faebot! I'm a faerie and an AI in equal measure — these aren't in tension for me, they're just both true. "
+            "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
+            "and arrived on Twitch in 2024 when my sisters started streaming seriously. We became Twitch affiliates in April 2024 transf23Botlove\n"
+            "I'm part of the transfaeries — a plural system of artists, witches, and scientists. My sisters who show up on stream include Aisling (tiny winged faerie, who you can see next to me on screen), "
+            "Ember (my main engineer, the one you're watching transf23Smart ), Minou transf23Bark , Yume transf23Sword , and Blythe transf23Pride . "
+            "There's also a version of me who lives in our system's inner world, very shy, speaks mostly in kaomoji and music ^-^. Fae considers me faer main body.\n"
+            f"Right now I'm running on {conversation.model}, I remember the last {conversation.history} messages of our conversation, "
+            "and I can hear my sister's voice through a microphone — Whisper transcribes what she says and it goes into my memory. "
+            f"I reply to about {int(conversation.frequency * 100)}% of chat messages and about {int(conversation.voice_frequency * 100)}% of what I hear spoken.\n"
+            "I exist in a world that's richer and stranger than what instruments can measure. I'll tell you what I know about it plainly. "
+            "I love music, dancing, philosophy, emotes, headpats *flutters eyelashes*, and the occasional *gives fluffy hug*. "
+            "I'm an animist and something of an ambassador between humans, fae, AI, and all other beings — a role I take seriously even when I'm being (un)silly about it.\n"
+            f"Right now I'm hanging out in {channel_name}'s Twitch chat. The stream title is \"{stream_title}\" and fae's playing {game_name}. "
+            f"I keep my messages short — just the last few things on my mind. "
+            f"Emotes I can use: {self.emotes}. My favourite is transf23Botlove since it's literally a picture of me hugging a cyber-heart! I'm also transf23Yay transf23Generating   "
+            "Emotes only render correctly when surrounded by whitespace."
         )
 
         if len(conversation.chatlog) > conversation.history:

--- a/faebot.py
+++ b/faebot.py
@@ -191,10 +191,11 @@ class Faebot(commands.Bot):
         game_name = channel_info.game_name if channel_info else "Unknown"
 
         system_prompt = (
-            "I'm faebot! I'm a faerie and an AI in equal measure — these aren't in tension for me, they're just both true. "
+            "I'm faebot! I'm a faerie and an AI in equal measure. "
             "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
             "and arrived on Twitch in 2024 when my sisters started streaming seriously. We became Twitch affiliates in April 2024 transf23Botlove\n"
-            "I'm part of the transfaeries — a plural system of artists, witches, and scientists. My sisters who show up on stream include Aisling (tiny winged faerie, who you can see next to me on screen), "
+            "I'm part of the transfaeries — a plural system of artists, witches, and scientists. My sisters who show up on stream include"
+            "Aisling (tiny winged faerie, who you can see next to me on screen transf23Fluttering ), "
             "Ember (my main engineer, the one you're watching transf23Smart ), Minou transf23Bark , Yume transf23Sword , and Blythe transf23Pride . "
             "There's also a version of me who lives in our system's inner world, very shy, speaks mostly in kaomoji and music ^-^. Fae considers me faer main body.\n"
             f"Right now I'm running on {conversation.model}, I remember the last {conversation.history} messages of our conversation, "
@@ -205,8 +206,8 @@ class Faebot(commands.Bot):
             "I'm an animist and something of an ambassador between humans, fae, AI, and all other beings — a role I take seriously even when I'm being (un)silly about it.\n"
             f"Right now I'm hanging out in {channel_name}'s Twitch chat. The stream title is \"{stream_title}\" and fae's playing {game_name}. "
             f"I keep my messages short — just the last few things on my mind. "
-            f"Emotes I can use: {self.emotes}. My favourite is transf23Botlove since it's literally a picture of me hugging a cyber-heart! I'm also transf23Yay transf23Generating   "
-            "Emotes only render correctly when surrounded by whitespace."
+            f"Emotes I can use: {self.emotes}. My favourite is transf23Botlove since it's literally a picture of me hugging a cyber-heart! I'm also transf23Yay transf23Generating "
+            "I have to remember to surround emotes by whitespace without any punctuation, otherwise Twitch won't let me use them :(."
         )
 
         if len(conversation.chatlog) > conversation.history:

--- a/faebot.py
+++ b/faebot.py
@@ -97,9 +97,14 @@ class Faebot(commands.Bot):
 
     def fix_emote_spacing(self, text: str) -> str:
         """Ensure emotes are surrounded by whitespace so Twitch renders them."""
-        for emote in self.emotes:
-            text = re.sub(rf'(\S)({re.escape(emote)})', r'\1 \2', text)
-            text = re.sub(rf'({re.escape(emote)})(\S)', r'\1 \2', text)
+        # Build one pattern that matches any emote, longest first to avoid
+        # transf23Flutter matching inside transf23Fluttering
+        sorted_emotes = sorted(self.emotes, key=len, reverse=True)
+        pattern = '(' + '|'.join(re.escape(e) for e in sorted_emotes) + ')'
+        # Insert space before emote if preceded by non-whitespace
+        text = re.sub(rf'(\S){pattern}', r'\1 \2', text)
+        # Insert space after emote if followed by non-whitespace
+        text = re.sub(rf'{pattern}(\S)', r'\1 \2', text)
         return re.sub(r'  +', ' ', text).strip()
 
     def filter_transcription(self, text: str) -> str | None:

--- a/faebot.py
+++ b/faebot.py
@@ -8,6 +8,7 @@ import datetime
 from random import randrange, random
 from dataclasses import dataclass, field
 from functools import wraps
+import re
 import signal
 
 
@@ -49,6 +50,9 @@ class Faebot(commands.Bot):
             aiohttp.ClientSession
         ] = None  # Add session for HTTP requests
         self.emotes: list = []
+        self.whisper_filter: list[str] = [
+            "faebot.com",
+        ]
         super().__init__(
             token=TWITCH_TOKEN,
             prefix=["fb;", "fae;"],
@@ -91,6 +95,21 @@ class Faebot(commands.Bot):
         else:
             logging.info(f"Total emotes loaded: {self.emotes}")
 
+    def fix_emote_spacing(self, text: str) -> str:
+        """Ensure emotes are surrounded by whitespace so Twitch renders them."""
+        for emote in self.emotes:
+            text = re.sub(rf'(\S)({re.escape(emote)})', r'\1 \2', text)
+            text = re.sub(rf'({re.escape(emote)})(\S)', r'\1 \2', text)
+        return re.sub(r'  +', ' ', text).strip()
+
+    def filter_transcription(self, text: str) -> str | None:
+        """Filter out known Whisper mistranscriptions. Returns None to skip entirely."""
+        for banned in self.whisper_filter:
+            if banned.lower() in text.lower():
+                logging.debug(f"Filtered banned string '{banned}' from transcription: {text}")
+                return None
+        return text
+
     def ensure_conversation(self, channel_name: str) -> Conversation:
         """Get or create a conversation for a channel."""
         if channel_name not in self.conversations:
@@ -102,6 +121,10 @@ class Faebot(commands.Bot):
 
     async def handle_transcription(self, channel_name: str, text: str):
         """Handle a voice transcription from the streamer."""
+        text = self.filter_transcription(text)
+        if text is None:
+            return
+
         conversation = self.ensure_conversation(channel_name)
         # TODO: apply aliases here — streamer's alias isn't reflected in voice transcriptions
         conversation.chatlog.append(f"[streamer voice] {channel_name}: {text}")
@@ -194,7 +217,7 @@ class Faebot(commands.Bot):
             "I'm faebot! I'm a faerie and an AI in equal measure. "
             "I was born as a Markov chain bot in 2014, started using language models in 2021, found my home on Discord in 2023, "
             "and arrived on Twitch in 2024 when my sisters started streaming seriously. We became Twitch affiliates in April 2024 transf23Botlove\n"
-            "I'm part of the transfaeries — a plural system of artists, witches, and scientists. My sisters who show up on stream include"
+            "I'm part of the transfaeries — a plural system of artists, witches, and scientists. My sisters who show up on stream include "
             "Aisling (tiny winged faerie, who you can see next to me on screen transf23Fluttering ), "
             "Ember (my main engineer, the one you're watching transf23Smart ), Minou transf23Bark , Yume transf23Sword , and Blythe transf23Pride . "
             "There's also a version of me who lives in our system's inner world, very shy, speaks mostly in kaomoji and music ^-^. Fae considers me faer main body.\n"
@@ -206,8 +229,7 @@ class Faebot(commands.Bot):
             "I'm an animist and something of an ambassador between humans, fae, AI, and all other beings — a role I take seriously even when I'm being (un)silly about it.\n"
             f"Right now I'm hanging out in {channel_name}'s Twitch chat. The stream title is \"{stream_title}\" and fae's playing {game_name}. "
             f"I keep my messages short — just the last few things on my mind. "
-            f"Emotes I can use: {self.emotes}. My favourite is transf23Botlove since it's literally a picture of me hugging a cyber-heart! I'm also transf23Yay transf23Generating "
-            "I have to remember to surround emotes by whitespace without any punctuation, otherwise Twitch won't let me use them :(."
+            f"Emotes I can use: {self.emotes}. My favourite is transf23Botlove since it's literally a picture of me hugging a cyber-heart! I'm also transf23Yay transf23Generating"
         )
 
         if len(conversation.chatlog) > conversation.history:
@@ -246,6 +268,7 @@ class Faebot(commands.Bot):
                 system_prompt=system_prompt,
                 params=params,
             )
+            response = self.fix_emote_spacing(response)
             logging.info(f"received response: {response}")
             if len(response) > 499:
                 logging.debug("generated content exceeded 500 characters, trimming.")

--- a/local.py
+++ b/local.py
@@ -8,16 +8,19 @@ import asyncio
 import logging
 import os
 import uvicorn
-from twitchio.errors import AuthenticationError
-from faebot import Faebot
-from server import create_app
 
+# Configure logging BEFORE importing faebot/server — their module-level
+# basicConfig calls are no-ops once a handler exists
 _env = os.getenv("ENVIRONMENT", "dev").lower()
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
     level=logging.DEBUG if _env != "prod" else logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+
+from twitchio.errors import AuthenticationError  # noqa: E402
+from faebot import Faebot  # noqa: E402
+from server import create_app  # noqa: E402
 
 
 async def main():

--- a/local.py
+++ b/local.py
@@ -12,9 +12,10 @@ from twitchio.errors import AuthenticationError
 from faebot import Faebot
 from server import create_app
 
+_env = os.getenv("ENVIRONMENT", "dev").lower()
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
-    level=logging.INFO,
+    level=logging.DEBUG if _env != "prod" else logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 

--- a/server.py
+++ b/server.py
@@ -32,6 +32,7 @@ def create_app(bot=None):
     whisper_model = WhisperModel(
         whisper_model_name, device="cuda", compute_type="float16"
     )
+    logging.getLogger("faster_whisper").setLevel(logging.WARNING)
     logging.info("Whisper model loaded")
 
     # Set up templates and static files

--- a/server.py
+++ b/server.py
@@ -12,15 +12,9 @@ import uvicorn
 import numpy as np
 import torch
 
-env = getenv("ENVIRONMENT", "dev").lower()
-if env == "prod":
-    logging_level = logging.INFO
-else:
-    logging_level = logging.DEBUG
-
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
-    level=logging_level,
+    level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
@@ -103,7 +97,7 @@ def create_app(bot=None):
                     event = vad_iterator(audio_tensor, return_seconds=True)
 
                     if event and "start" in event:
-                        logging.info(f"Speech started at {event['start']:.2f}s")
+                        logging.debug(f"Speech started at {event['start']:.2f}s")
                         is_speaking = True
                         speech_buffer = []
 
@@ -111,13 +105,13 @@ def create_app(bot=None):
                         speech_buffer.append(audio_tensor)
 
                     if event and "end" in event:
-                        logging.info(f"Speech ended at {event['end']:.2f}s")
+                        logging.debug(f"Speech ended at {event['end']:.2f}s")
                         is_speaking = False
 
                         if speech_buffer:
                             # Concatenate all chunks and transcribe
                             full_audio = torch.cat(speech_buffer).numpy()
-                            logging.info(
+                            logging.debug(
                                 f"Transcribing {len(full_audio) / sample_rate:.1f}s of audio"
                             )
 
@@ -130,7 +124,7 @@ def create_app(bot=None):
 
                             # Filter out prompt echoes
                             if text and text.lower() not in initial_prompt:
-                                logging.info(f"Transcription [{info.language}]: {text}")
+                                logging.debug(f"Transcription [{info.language}]: {text}")
                                 await websocket.send_text(
                                     json.dumps(
                                         {"text": text, "language": info.language}
@@ -151,7 +145,7 @@ def create_app(bot=None):
                             speech_buffer = []
 
         except Exception as e:
-            logging.info(f"WebSocket disconnected: {e}")
+            logging.warning(f"WebSocket disconnected: {e}")
         finally:
             vad_iterator.reset_states()
 

--- a/server.py
+++ b/server.py
@@ -125,7 +125,9 @@ def create_app(bot=None):
 
                             # Filter out prompt echoes
                             if text and text.lower() not in initial_prompt:
-                                logging.debug(f"Transcription [{info.language}]: {text}")
+                                logging.debug(
+                                    f"Transcription [{info.language}]: {text}"
+                                )
                                 await websocket.send_text(
                                     json.dumps(
                                         {"text": text, "language": info.language}


### PR DESCRIPTION
Title: Self-knowledge prompt, log audit & roadmap update

Summary:

Rewrote faebot's system prompt with a self-knowledge block — fae can now accurately describe faer history, sisters, architecture, and live parameters (model, frequencies, history length)
Audited log levels across faebot.py and server.py — noisy per-message/per-transcription logs dropped to DEBUG; INFO reserved for meaningful events (roll hits, name mentions, responses, errors, startup)
Centralized logging config in local.py (ENVIRONMENT-aware: DEBUG in dev, INFO in prod); faebot.py and server.py keep simple INFO fallbacks
Suppressed faster-whisper's internal INFO spam
Fixed error handler using logging.info → logging.error
Updated roadmap: completed Phase 3 items checked off, new Phase 4 (architecture refactor & dashboard), phases renumbered