### PR TITLE
CI gate: make all on 3.11 + 3.13, and the rot it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# The gate, on every PR and on main — the same shape as faebot-core's.
+# The matrix runs what deploys (3.11 — the Dockerfile) and what fae runs
+# locally (3.13). Note: `poetry install` pulls torch + faster-whisper because
+# server.py imports them at module top; that is the slow part of this job.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Install dependencies
+        run: poetry install
+      - name: Run the gate
+        run: make all

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,29 @@
-.PHONY: test lint format static_type_check setup-hooks clean all
+.PHONY: format format-check lint typecheck test all clean
 
-# Default target
-all: black lint static_type_check test
+# The gate. Checks only — `make all` never rewrites files. CI runs this.
+all: format-check lint typecheck test
 
-# Run tests with pytest
-test:
-	@echo "Running tests with coverage..."
-	poetry run pytest -v tests/ --cov=. --cov-report=term-missing
-
-# Run linting with flake8
-lint:
-	@echo "Running linter..."
-	poetry run flake8 .
-
-# Format code with black
-black:
-	@echo "Running formatter..."
+# Rewrite code to house style (the only writing target).
+format:
 	poetry run black .
 
-# Run static type checking with mypy
-static_type_check:
-	@echo "Running static type checker..."
+# Fail (without writing) if formatting is off.
+format-check:
+	poetry run black --check .
+
+# Lint.
+lint:
+	poetry run flake8 .
+
+# Static types (snippets/ is scratch, not shipped).
+typecheck:
 	poetry run mypy . --exclude 'snippets/'
 
-# Setup pre-commit hooks
-setup-hooks:
-	@echo "Setting up git hooks..."
-	git config core.hooksPath .githooks
-	chmod +x .githooks/pre-commit
+# Tests with coverage.
+test:
+	poetry run pytest -v tests/ --cov=. --cov-report=term-missing
 
-# Clean up cache directories
+# Clean caches.
 clean:
-	@echo "Cleaning up..."
-	rm -rf .pytest_cache
-	rm -rf .mypy_cache
-	rm -rf .coverage
+	rm -rf .pytest_cache .mypy_cache .ruff_cache .coverage
 	find . -type d -name __pycache__ -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ poetry run python bot.py
 ### Development
 
 ```bash
-make lint              # flake8
-make black             # code formatting
-make static_type_check # mypy
-make all               # run everything
+make all           # the gate: black --check, flake8, mypy, pytest — never writes (CI runs this)
+make format        # rewrite code to house style (the one writing target)
+make lint          # flake8
+make typecheck     # mypy
+make test          # pytest with coverage
 ```
 
 ## Roadmap

--- a/bot.py
+++ b/bot.py
@@ -117,7 +117,7 @@ class Faebot(commands.Bot, FaebotCommands):
 
         text_normalized = re.sub(r"[^\w\s]", "", text.lower())
         if VOICE_ACTIVATION in text_normalized:
-            logging.info(f"Voice activation phrase detected, generating!")
+            logging.info("Voice activation phrase detected, generating!")
             asyncio.create_task(
                 self._generate_and_send(channel_name, trigger_type="voice")
             )

--- a/commands.py
+++ b/commands.py
@@ -5,6 +5,7 @@ Faebot inherits from this class to gain all fb;/fae; commands.
 
 from twitchio.ext import commands
 from functools import wraps
+from typing import Awaitable, Callable
 import os
 import logging
 
@@ -26,6 +27,11 @@ def requires_mod(command):
 
 class FaebotCommands:
     """Mixin providing all fb;/fae; chat commands."""
+
+    # Provided by twitchio's Bot when this mixin is composed into Faebot;
+    # declared here so mypy knows the mixin may call them.
+    join_channels: Callable[[list[str]], Awaitable[None]]
+    part_channels: Callable[[list[str]], Awaitable[None]]
 
     # --- commands for everyone ---
 
@@ -178,6 +184,8 @@ class FaebotCommands:
         """Invite faebot to join a channel."""
         if ctx.author.name not in ADMIN:
             return await ctx.send("sorry you need to be an admin to use that command")
+        if not user:
+            return await ctx.reply("usage: join <channel>")
 
         await self.join_channels([user])
         logging.info(f"Joined new channel: {user}")

--- a/local.py
+++ b/local.py
@@ -23,7 +23,6 @@ logging.basicConfig(
 logging.getLogger("torio").setLevel(logging.WARNING)  # suppress FFmpeg probe noise
 
 from twitchio.errors import AuthenticationError  # noqa: E402
-import core  # noqa: E402
 from bot import Faebot  # noqa: E402
 from server import create_app  # noqa: E402
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.2.0"
 description = "Faebot AI Chatbot for twitch with voice integration"
 authors = ["transfaeries"]
 readme = "README.md"
+# An app of flat modules, not a library: nothing to install as a package.
+# (The Dockerfile already says --no-root; this makes it true everywhere.)
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -58,7 +58,9 @@ class TestHandleTranscription:
         mock_faebot._generate_and_send = AsyncMock()
 
         with patch("bot.VOICE_ACTIVATION", "faebot dearest"):
-            await mock_faebot.handle_transcription("testchannel", "faebot dearest, what do you think?")
+            await mock_faebot.handle_transcription(
+                "testchannel", "faebot dearest, what do you think?"
+            )
 
         # Give the task a moment to be created
         await asyncio.sleep(0.01)
@@ -76,7 +78,9 @@ class TestHandleTranscription:
 
         # Patch random to return value that would trigger at 0.5 but not at voice_frequency
         with patch("core.random", return_value=0.3):
-            await mock_faebot.handle_transcription("testchannel", "hey faebot what's up")
+            await mock_faebot.handle_transcription(
+                "testchannel", "hey faebot what's up"
+            )
 
         await asyncio.sleep(0.01)
         mock_faebot._generate_and_send.assert_called_once()
@@ -90,7 +94,9 @@ class TestHandleTranscription:
 
         # Roll of 0.05 should trigger at voice_frequency 0.1
         with patch("core.random", return_value=0.05):
-            await mock_faebot.handle_transcription("testchannel", "just talking about stuff")
+            await mock_faebot.handle_transcription(
+                "testchannel", "just talking about stuff"
+            )
 
         await asyncio.sleep(0.01)
         mock_faebot._generate_and_send.assert_called_once()
@@ -104,7 +110,9 @@ class TestHandleTranscription:
 
         # Roll of 0.5 should NOT trigger at voice_frequency 0.1
         with patch("core.random", return_value=0.5):
-            await mock_faebot.handle_transcription("testchannel", "just talking about stuff")
+            await mock_faebot.handle_transcription(
+                "testchannel", "just talking about stuff"
+            )
 
         await asyncio.sleep(0.01)
         mock_faebot._generate_and_send.assert_not_called()
@@ -138,7 +146,9 @@ class TestGenerateAndSend:
         assert event["channel"] == "testchannel"
 
     @pytest.mark.asyncio
-    async def test_generation_failure_emits_error_and_fallback(self, mock_faebot, openrouter_error):
+    async def test_generation_failure_emits_error_and_fallback(
+        self, mock_faebot, openrouter_error
+    ):
         """Generation failure should emit error event and send fallback message."""
         core.ensure_conversation("testchannel")
         openrouter_error(status=500, repeat=True)
@@ -152,7 +162,10 @@ class TestGenerateAndSend:
         # Check fallback message was sent
         mock_channel.send.assert_called()
         fallback_call = mock_channel.send.call_args
-        assert "oops" in fallback_call[0][0].lower() or "strange" in fallback_call[0][0].lower()
+        assert (
+            "oops" in fallback_call[0][0].lower()
+            or "strange" in fallback_call[0][0].lower()
+        )
 
         # Check error event was emitted (skip the generating event)
         event = await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)
@@ -162,7 +175,9 @@ class TestGenerateAndSend:
         assert event["type"] == "error"
 
     @pytest.mark.asyncio
-    async def test_send_failure_emits_error_event(self, mock_faebot, openrouter_success):
+    async def test_send_failure_emits_error_event(
+        self, mock_faebot, openrouter_success
+    ):
         """Send failure should emit error event with same generation_id."""
         core.ensure_conversation("testchannel")
         openrouter_success("hello!")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,7 +6,7 @@ we call the callback function directly via `command_method._callback(instance, c
 """
 
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, AsyncMock
 import core
 
 
@@ -26,7 +26,9 @@ class TestRequiresMod:
         # Call the callback directly, bypassing TwitchIO Command machinery
         await instance.clear._callback(instance, ctx)
 
-        assert "cleared" in ctx.replies[0].lower() or "forgotten" in ctx.replies[0].lower()
+        assert (
+            "cleared" in ctx.replies[0].lower() or "forgotten" in ctx.replies[0].lower()
+        )
 
     @pytest.mark.asyncio
     async def test_admin_can_use_command(self, mock_context):
@@ -40,7 +42,9 @@ class TestRequiresMod:
             instance = FaebotCommands()
             await instance.clear._callback(instance, ctx)
 
-        assert "cleared" in ctx.replies[0].lower() or "forgotten" in ctx.replies[0].lower()
+        assert (
+            "cleared" in ctx.replies[0].lower() or "forgotten" in ctx.replies[0].lower()
+        )
 
     @pytest.mark.asyncio
     async def test_regular_user_blocked(self, mock_context):
@@ -169,7 +173,9 @@ class TestAliasCommand:
         instance = FaebotCommands()
         await instance.alias._callback(instance, ctx)
 
-        assert "haven't" in ctx.replies[0].lower() or "set one" in ctx.replies[0].lower()
+        assert (
+            "haven't" in ctx.replies[0].lower() or "set one" in ctx.replies[0].lower()
+        )
 
     @pytest.mark.asyncio
     async def test_alias_added_to_chatlog(self, mock_context):
@@ -409,7 +415,9 @@ class TestAdminCommands:
         """model with arg should set new model."""
         from commands import FaebotCommands
 
-        ctx = mock_context("fae;model anthropic/claude-3-haiku", author_name="transfaeries")
+        ctx = mock_context(
+            "fae;model anthropic/claude-3-haiku", author_name="transfaeries"
+        )
         conv = core.ensure_conversation("testchannel")
 
         with patch("commands.ADMIN", ["transfaeries"]):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,7 @@ due to the complexity of mocking audio processing and CUDA models.
 
 import asyncio
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 
 
@@ -23,12 +23,14 @@ def event_queue():
 def test_app(event_queue):
     """Create a test FastAPI app with mocked VAD/Whisper models."""
     # Mock the heavy ML models before importing server
-    with patch("server.load_silero_vad") as mock_vad, \
-         patch("server.WhisperModel") as mock_whisper:
+    with patch("server.load_silero_vad") as mock_vad, patch(
+        "server.WhisperModel"
+    ) as mock_whisper:
         mock_vad.return_value = MagicMock()
         mock_whisper.return_value = MagicMock()
 
         from server import create_app
+
         app = create_app(bot=None, events=event_queue)
         yield app
 
@@ -63,9 +65,8 @@ class TestHomeEndpoint:
 class TestEventsWebSocket:
     def test_websocket_connects(self, client):
         """Events WebSocket should accept connections."""
-        with client.websocket_connect("/ws/events") as websocket:
-            # Connection successful if we get here
-            pass
+        with client.websocket_connect("/ws/events"):
+            pass  # connection successful if we get here
 
     def test_replays_history_on_connect(self, test_app, event_queue):
         """New connections should receive event history from ring buffer."""
@@ -92,8 +93,6 @@ class TestEventsWebSocket:
                 test_event = {"type": "response", "id": "live-1", "text": "hello"}
 
                 # Push to all connected clients directly (simulating drain)
-                import asyncio
-
                 async def push_event():
                     for ws in list(test_app.state.event_clients):
                         await ws.send_json(test_event)
@@ -116,19 +115,15 @@ class TestEventDrain:
     @pytest.mark.asyncio
     async def test_drain_adds_to_history(self, event_queue):
         """Events from queue should be added to ring buffer."""
-        with patch("server.load_silero_vad") as mock_vad, \
-             patch("server.WhisperModel") as mock_whisper:
+        with patch("server.load_silero_vad") as mock_vad, patch(
+            "server.WhisperModel"
+        ) as mock_whisper:
             mock_vad.return_value = MagicMock()
             mock_whisper.return_value = MagicMock()
 
             from server import create_app
-            app = create_app(bot=None, events=event_queue)
 
-            # Manually start the drain task
-            drain_task = None
-            for attr in dir(app.state):
-                if "drain" in attr.lower():
-                    drain_task = getattr(app.state, attr, None)
+            app = create_app(bot=None, events=event_queue)
 
             # Push an event to the queue
             await event_queue.put({"type": "test", "id": "drain-1"})
@@ -143,12 +138,14 @@ class TestEventDrain:
     @pytest.mark.asyncio
     async def test_event_history_capped_at_50(self):
         """Ring buffer should cap at 50 events."""
-        with patch("server.load_silero_vad") as mock_vad, \
-             patch("server.WhisperModel") as mock_whisper:
+        with patch("server.load_silero_vad") as mock_vad, patch(
+            "server.WhisperModel"
+        ) as mock_whisper:
             mock_vad.return_value = MagicMock()
             mock_whisper.return_value = MagicMock()
 
             from server import create_app
+
             event_queue = asyncio.Queue()
             app = create_app(bot=None, events=event_queue)
 


### PR DESCRIPTION
## The gate

faebot-twitch had 109 tests and nothing enforcing them — which is how PR #15's body came to say "CI-proven" with no CI (both reviewers caught it). This is the gate, in faebot-core's shape (core PR #4):

- **`.github/workflows/ci.yml`** — runs `make all` on every PR and on `main`, matrix **3.11** (what the Dockerfile deploys) + **3.13** (what runs locally).
- **`make all` is now check-only**: `black --check` · `flake8` · `mypy` · `pytest`. `make format` is the one writing target (it used to *run* black inside `all`, so it wasn't a gate). Dead `setup-hooks` target removed — `.githooks/` never existed.
- Kept black/flake8 rather than converting to ruff: a gate PR should be small and prove the tools the repo already has. Ruff convergence (core's config) is a later, separate change.

## The rot it found at HEAD (second commit, all pre-existing)

- black would reformat three test files
- flake8: unused imports/vars in tests, an f-string with no placeholders, `local.py`'s bare `import core`
- mypy: `FaebotCommands` is a mixin calling `Bot.join_channels`/`part_channels`; declared on the mixin. That exposed the **one behaviour change in this PR**: `join` with no argument would have called `join_channels([None])`; it now replies `usage: join <channel>`.

## What CI proves and what it doesn't

`make all` is green locally on 3.13. **CI's own run is the point of this PR** — the workflow has never executed before, and the cost of `poetry install` (torch + faster-whisper, because `server.py` imports them at module top) is measured on this run, not estimated. If it's painful, lazy voice imports are a follow-up, not part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
