### PR TITLE
The reasoning channel, kimi-k3, and silence as a verb

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -152,7 +152,7 @@ class Faebot(commands.Bot, FaebotCommands):
 
         generation_id = str(uuid.uuid4())
         try:
-            response = await core.generate_response(
+            completion = await core.generate_response(
                 channel_name=channel_name,
                 stream_title=stream_title,
                 game_name=game_name,
@@ -171,6 +171,8 @@ class Faebot(commands.Bot, FaebotCommands):
             except Exception as fallback_e:
                 logging.error(f"Failed to send fallback message too: {fallback_e}")
             return
+
+        response = completion.text
 
         try:
             await channel.send(response)
@@ -199,11 +201,13 @@ class Faebot(commands.Bot, FaebotCommands):
         # event_notice and correlate to the most recent send per channel.
         # See ROADMAP "Twitch NOTICE handling".
         # Capture tap — faebot's own utterance perceived back into the stream.
+        # Reasoning + latency ride along, so the capture doubles as data.
         capture.record_faebot_message(
             channel_name,
             response,
             generation_id=generation_id,
             trigger_type=trigger_type,
+            **completion.capture_meta(),
         )
 
         core.put_event(
@@ -213,6 +217,7 @@ class Faebot(commands.Bot, FaebotCommands):
                 "id": generation_id,
                 "channel": channel_name,
                 "text": response,
+                **completion.capture_meta(),
             },
         )
 

--- a/bot.py
+++ b/bot.py
@@ -162,14 +162,21 @@ class Faebot(commands.Bot, FaebotCommands):
                 generation_id=generation_id,
             )
         except Exception as e:
-            # core has already emitted an `error` event for this generation
+            # core has already emitted an `error` event for this generation.
+            # Nothing goes to chat: a failure of the machinery is not
+            # something faebot said (the old "Oops, something strange has
+            # happened" fallback landed fifteen minutes late on 08-20 and
+            # apologised in faer voice for our timeout). The capture keeps
+            # it — faebot was asked, and the machinery failed — so it is
+            # part of what happened in the room.
             logging.error(f"Generation failed: {e}")
-            try:
-                await channel.send(
-                    "Oops, something strange has happened. Please let the developer know!"
-                )
-            except Exception as fallback_e:
-                logging.error(f"Failed to send fallback message too: {fallback_e}")
+            capture.record_faebot_error(
+                channel_name,
+                f"{type(e).__name__}: {e}",
+                generation_id=generation_id,
+                trigger_type=trigger_type,
+                elapsed=getattr(e, "elapsed", None),
+            )
             return
 
         if completion.passed:

--- a/bot.py
+++ b/bot.py
@@ -172,6 +172,28 @@ class Faebot(commands.Bot, FaebotCommands):
                 logging.error(f"Failed to send fallback message too: {fallback_e}")
             return
 
+        if completion.passed:
+            # faebot chose silence: nothing to chat, but the choice is kept —
+            # the capture (for memory faebot) and the dashboard both see it.
+            capture.record_faebot_pass(
+                channel_name,
+                completion.reason_for_passing,
+                generation_id=generation_id,
+                trigger_type=trigger_type,
+                **completion.capture_meta(),
+            )
+            core.put_event(
+                self.event_queue,
+                {
+                    "type": "pass",
+                    "id": generation_id,
+                    "channel": channel_name,
+                    "reason": completion.reason_for_passing,
+                    **completion.capture_meta(),
+                },
+            )
+            return
+
         response = completion.text
 
         try:

--- a/capture.py
+++ b/capture.py
@@ -141,6 +141,21 @@ def record_faebot_message(channel_name: str, text: str, **meta) -> None:
         logging.debug(f"capture_faebot failed: {type(error).__name__}: {error}")
 
 
+def record_faebot_pass(channel_name: str, reason: str, **meta) -> None:
+    """Record faebot choosing silence — a generation that ended in the silence
+    sentinel, so nothing was posted. Its own kind, because "thought about it
+    and stayed quiet" is a real act, distinct from both a message and an
+    absence; `reason` is what fae said after the sentinel (may be empty) and
+    `meta` carries the reasoning channel like record_faebot_message does.
+    """
+    if not is_enabled():
+        return
+    try:
+        record("faebot_pass", channel=channel_name, reason=reason, **meta)
+    except Exception as error:
+        logging.debug(f"capture_faebot_pass failed: {type(error).__name__}: {error}")
+
+
 # Pure protocol keepalives — no perceptual content, skipped so the raw catch-all
 # doesn't drown the log. Everything else raw is kept.
 _RAW_SKIP_PREFIXES = ("PING", "PONG")

--- a/capture.py
+++ b/capture.py
@@ -156,6 +156,21 @@ def record_faebot_pass(channel_name: str, reason: str, **meta) -> None:
         logging.debug(f"capture_faebot_pass failed: {type(error).__name__}: {error}")
 
 
+def record_faebot_error(channel_name: str, error: str, **meta) -> None:
+    """Record a generation that FAILED after faebot was asked — the service
+    timed out, refused, or was unreachable, and nothing was posted. Not
+    faebot's act (fae never got to answer) but part of what happened in the
+    room, and a data point (`elapsed` rides in `meta`). Application-health
+    detail (tracebacks, reconnects) belongs in a log file, not here.
+    """
+    if not is_enabled():
+        return
+    try:
+        record("faebot_error", channel=channel_name, error=error, **meta)
+    except Exception as err:
+        logging.debug(f"capture_faebot_error failed: {type(err).__name__}: {err}")
+
+
 # Pure protocol keepalives — no perceptual content, skipped so the raw catch-all
 # doesn't drown the log. Everything else raw is kept.
 _RAW_SKIP_PREFIXES = ("PING", "PONG")

--- a/core.py
+++ b/core.py
@@ -3,10 +3,11 @@ Core brain for faebot — conversation management, generation logic, reply decis
 No TwitchIO or FastAPI dependencies. Both bot.py and server.py import from here.
 """
 
-from typing import Optional
-from dataclasses import dataclass, field
+from typing import Any, Optional
+from dataclasses import dataclass, field, replace
 from random import randrange, random
 import os
+import time
 import aiohttp
 import asyncio
 import datetime
@@ -15,7 +16,24 @@ import re
 import uuid
 
 
-MODEL = os.getenv("MODEL", "google/gemini-2.5-flash")
+# Startup defaults, all env-readable. These are the *defaults* a fresh
+# Conversation starts from; the fae;freq / fae;hist mod commands still change
+# them live and those changes still don't persist across restarts (that is the
+# other half of the "runtime dials don't persist" item, not done here).
+MODEL = os.getenv("MODEL", "moonshotai/kimi-k3")
+HISTORY = int(os.getenv("HISTORY", "50"))
+FREQUENCY = float(os.getenv("FREQUENCY", "0.05"))
+VOICE_FREQUENCY = float(os.getenv("VOICE_FREQUENCY", "0.025"))
+
+# Token caps are SAFETY NETS, not instructions (fae, 2026-08-19). The model
+# has no view of its own budget at generation time — `max_tokens` is a
+# server-side guillotine, and the only thing that shapes length is the prompt.
+# So both caps sit well above anything a normal reply needs, and hitting one
+# is a log line to investigate (`finish_reason == "length"`), not a design.
+# The reasoning cap rides ON TOP of the answer cap (learned in faebot-core:
+# sharing one purse let deliberation eat the reply).
+GENERATION_CAP = int(os.getenv("GENERATION_CAP", "500"))
+REASONING_CAP = int(os.getenv("REASONING_CAP", "8000"))
 
 
 @dataclass
@@ -24,11 +42,48 @@ class Conversation:
 
     channel: str
     chatlog: list = field(default_factory=list)
-    frequency: float = 0.05
-    voice_frequency: float = 0.025
-    history: int = 20
+    frequency: float = FREQUENCY
+    voice_frequency: float = VOICE_FREQUENCY
+    history: int = HISTORY
     model: str = MODEL
     silenced: bool = False
+
+
+@dataclass(frozen=True)
+class Completion:
+    """One generation, and how it came to be.
+
+    `text` is the answer channel and `reasoning` a separate one the model may
+    think in — kept apart (same shape as faebot-core's Completion) because the
+    two go different places: text to chat, reasoning to the dashboard and the
+    capture. `elapsed`/`finish_reason`/`usage` are kept so the capture file
+    doubles as latency data we can read after a stream.
+    """
+
+    text: str
+    reasoning: str = ""
+    elapsed: float = 0.0
+    finish_reason: str = ""
+    model: str = ""
+    usage: dict[str, Any] = field(default_factory=dict)
+    attempts: int = 1
+
+    @property
+    def is_empty(self) -> bool:
+        """An empty answer channel is a DROPPED PAYLOAD, never chosen silence —
+        reasoning models cause it by answering into `reasoning` instead."""
+        return not self.text.strip()
+
+    def capture_meta(self) -> dict[str, Any]:
+        """The provenance fields worth writing alongside faebot's utterance."""
+        return {
+            "reasoning": self.reasoning,
+            "elapsed": self.elapsed,
+            "finish_reason": self.finish_reason,
+            "model": self.model,
+            "usage": self.usage,
+            "attempts": self.attempts,
+        }
 
 
 conversations: dict[str, Conversation] = {}
@@ -170,10 +225,10 @@ async def generate_response(
     events: Optional[asyncio.Queue] = None,
     trigger_type: str = "chat",
     generation_id: Optional[str] = None,
-) -> str:
-    """Build prompt, call the API, return the response text.
+) -> Completion:
+    """Build prompt, call the API, return the Completion (text + reasoning).
 
-    The caller is responsible for sending the response to chat
+    The caller is responsible for sending `.text` to chat
     and for fetching stream_title/game_name from TwitchIO.
 
     If `events` is provided, this emits `generating` and (on API failure)
@@ -241,7 +296,7 @@ async def generate_response(
     )
 
     try:
-        response = await generate(
+        completion = await generate(
             model=conversation.model,
             prompt=prompt,
             system_prompt=system_prompt,
@@ -259,8 +314,21 @@ async def generate_response(
         )
         raise
 
-    response = fix_emote_spacing(response, emotes)
-    logging.info(f"received response: {response}")
+    response = fix_emote_spacing(completion.text, emotes)
+    logging.info(
+        f"received response in {completion.elapsed:.1f}s "
+        f"(finish_reason={completion.finish_reason!r}, attempts={completion.attempts}): {response}"
+    )
+    if completion.reasoning:
+        logging.debug(f"reasoning: {completion.reasoning}")
+    if completion.finish_reason == "length":
+        logging.warning(
+            "generation hit the token cap (finish_reason=length) \u2014 "
+            "the cap is a safety net; if this recurs, look at the prompt first"
+        )
+    # IRC messages are one line. kimi writes multi-line replies (gemini never
+    # did); fold them rather than let TwitchIO truncate at the first newline.
+    response = " ".join(line.strip() for line in response.splitlines() if line.strip())
     if len(response) > 499:
         logging.debug("generated content exceeded 500 characters, trimming.")
         response = response[:499] + "\u2013"
@@ -270,7 +338,15 @@ async def generate_response(
 
     conversation.chatlog.append(f"faebot: {response}")
 
-    return response
+    return replace(completion, text=response)
+
+
+# The answer channel coming back empty is a dropped payload (the model spoke
+# into `reasoning` and left `content` blank \u2014 kimi does this), so we roll once
+# more. Bounded: resampling cures stochastic drops, never structural failures.
+EMPTY_ROLLS = 2
+
+FALLBACK_TEXT = "I couldn't generate a response. Please try again."
 
 
 async def generate(
@@ -278,8 +354,30 @@ async def generate(
     model: str = MODEL,
     system_prompt: str = "",
     params: dict | None = None,
-) -> str:
-    """Generate completions with the OpenRouter API."""
+) -> Completion:
+    """Generate a Completion with the OpenRouter API, rolling again on an
+    empty answer channel."""
+    for roll in range(1, EMPTY_ROLLS + 1):
+        completion = await _generate_once(
+            prompt=prompt, model=model, system_prompt=system_prompt, params=params
+        )
+        completion = replace(completion, attempts=roll)
+        if not completion.is_empty:
+            return completion
+        logging.warning(
+            f"empty answer channel (reasoning had {len(completion.reasoning)} chars) "
+            f"\u2014 rolling again ({roll}/{EMPTY_ROLLS})"
+        )
+    return completion
+
+
+async def _generate_once(
+    prompt: str,
+    model: str,
+    system_prompt: str,
+    params: dict | None,
+) -> Completion:
+    """One call to OpenRouter's chat completions, with HTTP-level retries."""
 
     if params is None:
         params = {"top_k": 75, "top_p": 1, "temperature": 0.7, "seed": 666}
@@ -293,6 +391,7 @@ async def generate(
 
     max_retries = 3
     for attempt in range(max_retries):
+        started = time.monotonic()
         try:
             async with session.post(
                 url="https://openrouter.ai/api/v1/chat/completions",
@@ -308,7 +407,9 @@ async def generate(
                     "model": model,
                     "messages": messages,
                     "temperature": params.get("temperature", 0.7),
-                    "max_tokens": 150,
+                    # Answer budget plus the reasoning's own room on top.
+                    "max_tokens": GENERATION_CAP + REASONING_CAP,
+                    "reasoning": {"max_tokens": REASONING_CAP},
                     "top_p": params.get("top_p", 1.0),
                 },
             ) as response:
@@ -324,18 +425,27 @@ async def generate(
                 if response.status >= 400:
                     body = await response.text()
                     logging.error(f"OpenRouter returned {response.status}: {body}")
-                    return "I couldn't generate a response. Please try again."
+                    return Completion(text=FALLBACK_TEXT, model=model)
 
                 result = await response.json()
+                elapsed = time.monotonic() - started
 
                 if "choices" in result and len(result["choices"]) > 0:
-                    reply = result["choices"][0]["message"]["content"]
-                    return str(reply)
+                    choice = result["choices"][0]
+                    message = choice.get("message") or {}
+                    return Completion(
+                        text=str(message.get("content") or ""),
+                        reasoning=str(message.get("reasoning") or ""),
+                        elapsed=elapsed,
+                        finish_reason=str(choice.get("finish_reason") or ""),
+                        model=str(result.get("model") or model),
+                        usage=result.get("usage") or {},
+                    )
                 else:
                     logging.error(
                         f"Unexpected response format from OpenRouter: {result}"
                     )
-                    return "I couldn't generate a response. Please try again."
+                    return Completion(text=FALLBACK_TEXT, model=model)
 
         except (aiohttp.ClientError, ValueError, asyncio.TimeoutError) as e:
             retry_after = min(2**attempt, 8)

--- a/core.py
+++ b/core.py
@@ -51,6 +51,12 @@ TOP_P = float(os.getenv("TOP_P", "0.95"))
 # is reported to the dashboard and the capture, never spoken in faebot's voice.
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "90"))
 
+# The one exception to one-attempt: a 429. OpenRouter's shared Moonshot
+# pool rate-limited three asks on the 08-21 stream, and a shared-pool 429
+# clears in about a second — unlike a timeout, which never does. So: ONE
+# immediate retry, on 429 only, after a short pause. Nothing else retries.
+RATE_LIMIT_RETRY_DELAY = float(os.getenv("RATE_LIMIT_RETRY_DELAY", "1.0"))
+
 
 @dataclass
 class Conversation:
@@ -143,10 +149,17 @@ class GenerationFailed(Exception):
     silence: this is the call failing. Carries `elapsed` so a failure is
     still a data point."""
 
-    def __init__(self, reason: str, elapsed: float = 0.0) -> None:
+    def __init__(
+        self, reason: str, elapsed: float = 0.0, status: int | None = None
+    ) -> None:
         super().__init__(reason)
         self.reason = reason
         self.elapsed = elapsed
+        self.status = status
+
+    @property
+    def is_rate_limit(self) -> bool:
+        return self.status == 429
 
 
 conversations: dict[str, Conversation] = {}
@@ -426,9 +439,20 @@ async def generate(
     """Generate a Completion with the OpenRouter API, rolling again on an
     empty answer channel."""
     for roll in range(1, EMPTY_ROLLS + 1):
-        completion = await _generate_once(
-            prompt=prompt, model=model, system_prompt=system_prompt, params=params
-        )
+        try:
+            completion = await _generate_once(
+                prompt=prompt, model=model, system_prompt=system_prompt, params=params
+            )
+        except GenerationFailed as failure:
+            if not failure.is_rate_limit:
+                raise
+            logging.warning(
+                f"rate-limited (429) — one retry in {RATE_LIMIT_RETRY_DELAY:g}s"
+            )
+            await asyncio.sleep(RATE_LIMIT_RETRY_DELAY)
+            completion = await _generate_once(
+                prompt=prompt, model=model, system_prompt=system_prompt, params=params
+            )
         completion = replace(completion, attempts=roll, params=dict(params or {}))
         if not completion.is_empty:
             return completion
@@ -446,7 +470,8 @@ async def _generate_once(
     params: dict | None,
 ) -> Completion:
     """One call to OpenRouter's chat completions. One attempt, real timeout;
-    any failure raises GenerationFailed (see REQUEST_TIMEOUT)."""
+    any failure raises GenerationFailed (see REQUEST_TIMEOUT). The single
+    429 retry lives in generate(), which is the caller that decides policy."""
 
     if params is None:
         params = {"temperature": TEMPERATURE, "top_p": TOP_P}
@@ -485,7 +510,9 @@ async def _generate_once(
             if response.status >= 400:
                 body = (await response.text())[:400]
                 raise GenerationFailed(
-                    f"OpenRouter returned {response.status}: {body}", elapsed
+                    f"OpenRouter returned {response.status}: {body}",
+                    elapsed,
+                    status=response.status,
                 )
 
             result = await response.json()

--- a/core.py
+++ b/core.py
@@ -57,6 +57,14 @@ REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "90"))
 # immediate retry, on 429 only, after a short pause. Nothing else retries.
 RATE_LIMIT_RETRY_DELAY = float(os.getenv("RATE_LIMIT_RETRY_DELAY", "1.0"))
 
+# The other exception: an upstream drop. Moonshot times out on a few asks a
+# night (a 504 — sometimes as an HTTP status, sometimes inside a 200 body:
+# `{"error": {"code": 504}}`). OpenRouter only walks the provider order when
+# a host is down at routing time, so a drop mid-call never reaches the next
+# pinned provider on its own. We do that ourselves: ONE retry, aimed at the
+# rest of the pinned list, never outside it. A cold cache beats a lost ask.
+UPSTREAM_DROP_STATUSES = (502, 503, 504)
+
 # Provider pinning, for the prompt cache and for the reasoning channel: only
 # some OpenRouter providers cache the prompt (on the 08-21 stream, unpinned:
 # Modal 32/35 calls hit, Moonshot 10/14, nine other providers 0/28), and some
@@ -182,6 +190,10 @@ class GenerationFailed(Exception):
     @property
     def is_rate_limit(self) -> bool:
         return self.status == 429
+
+    @property
+    def is_upstream_drop(self) -> bool:
+        return self.status in UPSTREAM_DROP_STATUSES
 
 
 conversations: dict[str, Conversation] = {}
@@ -489,15 +501,31 @@ async def generate(
                 prompt=prompt, model=model, system_prompt=system_prompt, params=params
             )
         except GenerationFailed as failure:
-            if not failure.is_rate_limit:
+            if failure.is_rate_limit:
+                logging.warning(
+                    f"rate-limited (429) — one retry in {RATE_LIMIT_RETRY_DELAY:g}s"
+                )
+                await asyncio.sleep(RATE_LIMIT_RETRY_DELAY)
+                completion = await _generate_once(
+                    prompt=prompt,
+                    model=model,
+                    system_prompt=system_prompt,
+                    params=params,
+                )
+            elif failure.is_upstream_drop and len(PROVIDERS) > 1:
+                logging.warning(
+                    f"upstream drop ({failure.status}) — one retry on "
+                    f"{','.join(PROVIDERS[1:])}"
+                )
+                completion = await _generate_once(
+                    prompt=prompt,
+                    model=model,
+                    system_prompt=system_prompt,
+                    params=params,
+                    providers=PROVIDERS[1:],
+                )
+            else:
                 raise
-            logging.warning(
-                f"rate-limited (429) — one retry in {RATE_LIMIT_RETRY_DELAY:g}s"
-            )
-            await asyncio.sleep(RATE_LIMIT_RETRY_DELAY)
-            completion = await _generate_once(
-                prompt=prompt, model=model, system_prompt=system_prompt, params=params
-            )
         completion = replace(completion, attempts=roll, params=dict(params or {}))
         if not completion.is_empty:
             return completion
@@ -508,15 +536,27 @@ async def generate(
     return completion
 
 
+def _body_error_code(result: object) -> int | None:
+    """OpenRouter can answer 200 with `{"error": {"code": 504, ...}}` — the
+    upstream's status, carried in the body. Surface it so policy can see it."""
+    if isinstance(result, dict):
+        error = result.get("error")
+        if isinstance(error, dict) and isinstance(error.get("code"), int):
+            return int(error["code"])
+    return None
+
+
 async def _generate_once(
     prompt: str,
     model: str,
     system_prompt: str,
     params: dict | None,
+    providers: tuple[str, ...] = PROVIDERS,
 ) -> Completion:
     """One call to OpenRouter's chat completions. One attempt, real timeout;
-    any failure raises GenerationFailed (see REQUEST_TIMEOUT). The single
-    429 retry lives in generate(), which is the caller that decides policy."""
+    any failure raises GenerationFailed (see REQUEST_TIMEOUT). The 429 and
+    upstream-drop retries live in generate(), the caller that decides policy;
+    `providers` is how a retry is aimed at the rest of the pinned list."""
 
     if params is None:
         params = {"temperature": TEMPERATURE, "top_p": TOP_P}
@@ -549,8 +589,8 @@ async def _generate_once(
                 "max_tokens": GENERATION_CAP + REASONING_CAP,
                 "reasoning": {"max_tokens": REASONING_CAP},
                 **(
-                    {"provider": {"order": list(PROVIDERS), "allow_fallbacks": False}}
-                    if PROVIDERS
+                    {"provider": {"order": list(providers), "allow_fallbacks": False}}
+                    if providers
                     else {}
                 ),
             },
@@ -572,7 +612,9 @@ async def _generate_once(
                 choice = result["choices"][0]
             except (KeyError, IndexError, TypeError):
                 raise GenerationFailed(
-                    f"OpenRouter returned no choices: {str(result)[:200]}", elapsed
+                    f"OpenRouter returned no choices: {str(result)[:200]}",
+                    elapsed,
+                    status=_body_error_code(result),
                 ) from None
             message = choice.get("message") or {}
             return Completion(

--- a/core.py
+++ b/core.py
@@ -277,6 +277,26 @@ def build_system_prompt(
     )
 
 
+# Whisper is primed with our names (`initial_prompt`) so it spells them right,
+# and on near-silent audio it hallucinates that prompt back — sometimes twice,
+# sometimes with punctuation, sometimes with an "and". A plain substring test
+# let ~170 such lines through in August, and faebot kept hearing faer name
+# when nobody had said it. An echo is a line with NOTHING in it but the
+# prompt's words (and filler); a real sentence always has more.
+_ECHO_FILLER = {"and", "the", "oh", "a"}
+
+
+def is_prompt_echo(text: str, prompt: str) -> bool:
+    """Is this transcription just Whisper repeating its own prompt (or
+    nothing at all)? Speech in another script is not an echo — whether it
+    is real is a different question, left alone here."""
+    words = re.findall(r"\w+", text.lower())
+    if not words:
+        return True  # punctuation only
+    prompt_words = set(re.findall(r"\w+", prompt.lower()))
+    return all(word in prompt_words or word in _ECHO_FILLER for word in words)
+
+
 def fix_emote_spacing(text: str, emotes: list[str]) -> str:
     """Ensure emotes are surrounded by whitespace so Twitch renders them."""
     if not emotes:

--- a/core.py
+++ b/core.py
@@ -82,6 +82,17 @@ SENTINEL_SILENCE = "NOTHING-TO-SAY"
 _SILENCE_PATTERN = re.compile(r"^\W*nothing[\s-]+to[\s-]+say\b[\s\W]*", re.IGNORECASE)
 
 
+def history_floor(history: int) -> int:
+    """How far the chatlog is cut back once it overflows `history`.
+
+    Trimming to exactly the limit shifts the prompt's prefix by one line on
+    every call, so the provider's prompt cache never holds past the system
+    prompt. Dropping a fifth at a time keeps the prefix stable for many calls;
+    faebot remembers between the floor and the limit.
+    """
+    return history - history // 5
+
+
 def said_nothing(text: str) -> bool:
     """Did faebot choose silence? FALSE for empty text — that's a drop."""
     return bool(_SILENCE_PATTERN.match(text))
@@ -239,7 +250,7 @@ def build_system_prompt(
         "Aisling (tiny winged faerie, who you can see next to me on screen transf23Fluttering ), "
         "Ember (my main engineer, the one you're watching transf23Smart ), Minou transf23Bark , Yume transf23Sword , and Blythe transf23Pride . "
         "There's also a version of me who lives in our system's inner world, very shy, speaks mostly in kaomoji and music ^-^. Fae considers me faer main body.\n"
-        f"Right now I'm running on {conversation.model}, I remember the last {conversation.history} messages of our conversation, "
+        f"Right now I'm running on {conversation.model}, I remember between the last {history_floor(conversation.history)} and {conversation.history} messages of our conversation, "
         "and I can hear my sister's voice through a microphone — Whisper transcribes what she says and it goes into my memory. "
         f"I reply to about {int(conversation.frequency * 100)}% of chat messages and about {int(conversation.voice_frequency * 100)}% of what I hear spoken.\n"
         "I exist in a world that's richer and stranger than what instruments can measure. I'll tell you what I know about it plainly. "
@@ -327,11 +338,14 @@ async def generate_response(
         conversation, channel_name, stream_title, game_name, emotes
     )
 
+    # Trim in a block, not to exactly `history` (see history_floor): the
+    # prompt's prefix stays put for many calls, so the provider's cache holds.
     if len(conversation.chatlog) > conversation.history:
+        floor = history_floor(conversation.history)
         logging.debug(
-            f"message history has exceeded the set history length of {conversation.history}"
+            f"chatlog exceeded {conversation.history} lines — trimming to {floor}"
         )
-        conversation.chatlog = conversation.chatlog[-conversation.history :]
+        conversation.chatlog = conversation.chatlog[-floor:]
 
     prompt = "\n".join(conversation.chatlog) + "\nfaebot:"
     logging.debug(

--- a/core.py
+++ b/core.py
@@ -57,6 +57,17 @@ REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "90"))
 # immediate retry, on 429 only, after a short pause. Nothing else retries.
 RATE_LIMIT_RETRY_DELAY = float(os.getenv("RATE_LIMIT_RETRY_DELAY", "1.0"))
 
+# Provider pinning, for the prompt cache and for the reasoning channel: only
+# some OpenRouter providers cache the prompt (on the 08-21 stream, unpinned:
+# Modal 32/35 calls hit, Moonshot 10/14, nine other providers 0/28), and some
+# serve kimi-k3 without reasoning at all. Comma-separated OpenRouter provider
+# slugs, tried in order, no fallback to the field; empty = route freely.
+PROVIDERS = tuple(
+    slug.strip()
+    for slug in os.getenv("OPENROUTER_PROVIDERS", "moonshotai,modal").split(",")
+    if slug.strip()
+)
+
 
 @dataclass
 class Conversation:
@@ -517,6 +528,11 @@ async def _generate_once(
                 # Answer budget plus the reasoning's own room on top.
                 "max_tokens": GENERATION_CAP + REASONING_CAP,
                 "reasoning": {"max_tokens": REASONING_CAP},
+                **(
+                    {"provider": {"order": list(PROVIDERS), "allow_fallbacks": False}}
+                    if PROVIDERS
+                    else {}
+                ),
             },
             timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
         ) as response:

--- a/core.py
+++ b/core.py
@@ -54,7 +54,10 @@ REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "90"))
 # The one exception to one-attempt: a 429. OpenRouter's shared Moonshot
 # pool rate-limited three asks on the 08-21 stream, and a shared-pool 429
 # clears in about a second — unlike a timeout, which never does. So: ONE
-# immediate retry, on 429 only, after a short pause. Nothing else retries.
+# retry, after a short pause — and aimed at the rest of the pinned list
+# when there is one, like the drop retry below: the pool that just said
+# no is the pool a same-list retry asks again (five asks lost that way on
+# the 08-27 stream). With a single pinned provider it asks the same one.
 RATE_LIMIT_RETRY_DELAY = float(os.getenv("RATE_LIMIT_RETRY_DELAY", "1.0"))
 
 # The other exception: an upstream drop. Moonshot times out on a few asks a
@@ -498,34 +501,33 @@ async def generate(
     for roll in range(1, EMPTY_ROLLS + 1):
         try:
             completion = await _generate_once(
-                prompt=prompt, model=model, system_prompt=system_prompt, params=params
+                prompt=prompt,
+                model=model,
+                system_prompt=system_prompt,
+                params=params,
+                providers=PROVIDERS,
             )
         except GenerationFailed as failure:
+            rest = PROVIDERS[1:] if len(PROVIDERS) > 1 else PROVIDERS
             if failure.is_rate_limit:
                 logging.warning(
                     f"rate-limited (429) — one retry in {RATE_LIMIT_RETRY_DELAY:g}s"
+                    f" on {','.join(rest) or 'any provider'}"
                 )
                 await asyncio.sleep(RATE_LIMIT_RETRY_DELAY)
-                completion = await _generate_once(
-                    prompt=prompt,
-                    model=model,
-                    system_prompt=system_prompt,
-                    params=params,
-                )
             elif failure.is_upstream_drop and len(PROVIDERS) > 1:
                 logging.warning(
-                    f"upstream drop ({failure.status}) — one retry on "
-                    f"{','.join(PROVIDERS[1:])}"
-                )
-                completion = await _generate_once(
-                    prompt=prompt,
-                    model=model,
-                    system_prompt=system_prompt,
-                    params=params,
-                    providers=PROVIDERS[1:],
+                    f"upstream drop ({failure.status}) — one retry on {','.join(rest)}"
                 )
             else:
                 raise
+            completion = await _generate_once(
+                prompt=prompt,
+                model=model,
+                system_prompt=system_prompt,
+                params=params,
+                providers=rest,
+            )
         completion = replace(completion, attempts=roll, params=dict(params or {}))
         if not completion.is_empty:
             return completion

--- a/core.py
+++ b/core.py
@@ -49,6 +49,27 @@ class Conversation:
     silenced: bool = False
 
 
+# THE silence sentinel: chosen silence must be SAID, so it can never be
+# confused with a dropped payload (empty content). A coined hyphenated phrase,
+# the same grammar as faebot-core's NOTHING-TO-RECORD, because a coined phrase
+# has no natural collisions — which is what lets matching be case-insensitive.
+# Anchored at the start of the reply; whatever follows it is faebot's reason
+# for passing, which is kept (captured, shown) but never posted. (The two
+# sentinels want one home eventually; noted in core-roadmap.)
+SENTINEL_SILENCE = "NOTHING-TO-SAY"
+_SILENCE_PATTERN = re.compile(r"^\W*nothing[\s-]+to[\s-]+say\b[\s\W]*", re.IGNORECASE)
+
+
+def said_nothing(text: str) -> bool:
+    """Did faebot choose silence? FALSE for empty text — that's a drop."""
+    return bool(_SILENCE_PATTERN.match(text))
+
+
+def pass_reason(text: str) -> str:
+    """What faebot said after the sentinel, if anything — faer reason."""
+    return _SILENCE_PATTERN.sub("", text, count=1).strip()
+
+
 @dataclass(frozen=True)
 class Completion:
     """One generation, and how it came to be.
@@ -73,6 +94,15 @@ class Completion:
         """An empty answer channel is a DROPPED PAYLOAD, never chosen silence —
         reasoning models cause it by answering into `reasoning` instead."""
         return not self.text.strip()
+
+    @property
+    def passed(self) -> bool:
+        """faebot chose silence (said the sentinel). Nothing gets posted."""
+        return said_nothing(self.text)
+
+    @property
+    def reason_for_passing(self) -> str:
+        return pass_reason(self.text) if self.passed else ""
 
     def capture_meta(self) -> dict[str, Any]:
         """The provenance fields worth writing alongside faebot's utterance."""
@@ -171,6 +201,10 @@ def build_system_prompt(
         "I'm an animist and something of an ambassador between humans, fae, AI, and all other beings — a role I take seriously even when I'm being (un)silly about it.\n"
         f"Right now I'm hanging out in {channel_name}'s Twitch chat. The stream title is \"{stream_title}\" and fae's playing {game_name}. "
         f"I keep my messages short — just the last few things on my mind. "
+        f"I think before I speak. Chat moves fast, so I think quickly, but a moment's thought is fine. "
+        f"My messages are one line and fit in 500 characters. "
+        f"If I've nothing to add, or I'd rather just listen, I answer {SENTINEL_SILENCE} "
+        f"(I can say why after it, if I like) and nothing gets posted. "
         f"Emotes I can use: {emotes}. My favourite is transf23Botlove since it's literally a picture of me hugging a cyber-heart! I'm also transf23Yay transf23Generating"
     )
 
@@ -313,6 +347,18 @@ async def generate_response(
             },
         )
         raise
+
+    if completion.passed:
+        # Chosen silence. The reason (if fae gave one) is kept for the capture
+        # and the dashboard; the chatlog records only the fact, so fae
+        # remembers having chosen it without the reason being echoable.
+        logging.info(
+            f"faebot passed in {completion.elapsed:.1f}s"
+            f" — {completion.reason_for_passing or '(no reason given)'}"
+        )
+        permalog(f"faebot passed: {completion.reason_for_passing}\n")
+        conversation.chatlog.append("faebot: *stays quiet*")
+        return completion
 
     response = fix_emote_spacing(completion.text, emotes)
     logging.info(

--- a/core.py
+++ b/core.py
@@ -5,7 +5,7 @@ No TwitchIO or FastAPI dependencies. Both bot.py and server.py import from here.
 
 from typing import Any, Optional
 from dataclasses import dataclass, field, replace
-from random import randrange, random
+from random import random
 import os
 import time
 import aiohttp
@@ -34,6 +34,22 @@ VOICE_FREQUENCY = float(os.getenv("VOICE_FREQUENCY", "0.025"))
 # sharing one purse let deliberation eat the reply).
 GENERATION_CAP = int(os.getenv("GENERATION_CAP", "500"))
 REASONING_CAP = int(os.getenv("REASONING_CAP", "8000"))
+
+# Sampling is PINNED, not rolled (2026-08-21). The per-generation lottery
+# (temperature 0.75–1.5, top_p 0.5–1.0) dates from the gemini-flash era; on
+# kimi-k3 its hot corner (T >= 1.4 AND top_p = 1.0) produced word soup 4/4
+# times on the 08-20 stream — and Moonshot's own API reportedly ignores the
+# values anyway, so the lottery was never an honest experiment. These are
+# Moonshot's published defaults for k3. Moods, if faebot wants them, get
+# designed on purpose later, not inherited from dice.
+TEMPERATURE = float(os.getenv("TEMPERATURE", "1.0"))
+TOP_P = float(os.getenv("TOP_P", "0.95"))
+
+# One request, one chance. A reply that arrives after a retry cycle arrives
+# after the moment (the 08-20 "Oops" messages landed fifteen minutes late:
+# aiohttp's 300s default × 3 retries). No retries; a real timeout; a failure
+# is reported to the dashboard and the capture, never spoken in faebot's voice.
+REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "90"))
 
 
 @dataclass
@@ -86,7 +102,9 @@ class Completion:
     elapsed: float = 0.0
     finish_reason: str = ""
     model: str = ""
+    provider: str = ""
     usage: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
     attempts: int = 1
 
     @property
@@ -111,9 +129,24 @@ class Completion:
             "elapsed": self.elapsed,
             "finish_reason": self.finish_reason,
             "model": self.model,
+            "provider": self.provider,
+            "params": self.params,
             "usage": self.usage,
             "attempts": self.attempts,
         }
+
+
+class GenerationFailed(Exception):
+    """The generating service could not be reached, or would not answer.
+
+    Distinct from an empty Completion (a dropped payload) and from chosen
+    silence: this is the call failing. Carries `elapsed` so a failure is
+    still a data point."""
+
+    def __init__(self, reason: str, elapsed: float = 0.0) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.elapsed = elapsed
 
 
 conversations: dict[str, Conversation] = {}
@@ -292,23 +325,14 @@ async def generate_response(
         f"model: {conversation.model}\nsystem_prompt: \n{system_prompt}\nprompt: \n{prompt}"
     )
 
-    params = {
-        "temperature": randrange(75, 150) / 100,
-        "top_p": randrange(5, 11) / 10,
-        "top_k": randrange(1, 1024),
-        "seed": randrange(1, 1024),
-    }
+    params = {"temperature": TEMPERATURE, "top_p": TOP_P}
 
-    logging.debug(
-        f"generating with parameters: \nTemperature:{params['temperature']}\nTop_k:{params['top_k']} \ntop_p: {params['top_p']}\nseed: {params['seed']}"
-    )
+    logging.debug(f"generating with parameters: {params}")
     current_time = datetime.datetime.now()
     permalog(
         f"generating message in channel {channel_name}'s channel at {current_time}\n"
     )
-    permalog(
-        f"generating with parameters: \nTemperature:{params['temperature']}\nTop_k:{params['top_k']} \ntop_p: {params['top_p']}\nSeed: {params['seed']}\n"
-    )
+    permalog(f"generating with parameters: {params}\n")
 
     if generation_id is None:
         generation_id = str(uuid.uuid4())
@@ -392,8 +416,6 @@ async def generate_response(
 # more. Bounded: resampling cures stochastic drops, never structural failures.
 EMPTY_ROLLS = 2
 
-FALLBACK_TEXT = "I couldn't generate a response. Please try again."
-
 
 async def generate(
     prompt: str = "",
@@ -407,7 +429,7 @@ async def generate(
         completion = await _generate_once(
             prompt=prompt, model=model, system_prompt=system_prompt, params=params
         )
-        completion = replace(completion, attempts=roll)
+        completion = replace(completion, attempts=roll, params=dict(params or {}))
         if not completion.is_empty:
             return completion
         logging.warning(
@@ -423,10 +445,11 @@ async def _generate_once(
     system_prompt: str,
     params: dict | None,
 ) -> Completion:
-    """One call to OpenRouter's chat completions, with HTTP-level retries."""
+    """One call to OpenRouter's chat completions. One attempt, real timeout;
+    any failure raises GenerationFailed (see REQUEST_TIMEOUT)."""
 
     if params is None:
-        params = {"top_k": 75, "top_p": 1, "temperature": 0.7, "seed": 666}
+        params = {"temperature": TEMPERATURE, "top_p": TOP_P}
 
     session = await get_session()
 
@@ -435,72 +458,66 @@ async def _generate_once(
         {"role": "user", "content": prompt},
     ]
 
-    max_retries = 3
-    for attempt in range(max_retries):
-        started = time.monotonic()
-        try:
-            async with session.post(
-                url="https://openrouter.ai/api/v1/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {os.getenv('OPENROUTER_KEY', '')}",
-                    "HTTP-Referer": os.getenv(
-                        "SITE_URL", "https://github.com/transfaeries/faebot-twitch"
-                    ),
-                    "X-Title": "Faebot Twitch",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": model,
-                    "messages": messages,
-                    "temperature": params.get("temperature", 0.7),
-                    # Answer budget plus the reasoning's own room on top.
-                    "max_tokens": GENERATION_CAP + REASONING_CAP,
-                    "reasoning": {"max_tokens": REASONING_CAP},
-                    "top_p": params.get("top_p", 1.0),
-                },
-            ) as response:
-                if response.status == 429 or response.status >= 500:
-                    retry_after = min(2**attempt, 8)
-                    logging.warning(
-                        f"OpenRouter returned {response.status}, "
-                        f"retrying in {retry_after}s (attempt {attempt + 1}/{max_retries})"
-                    )
-                    await asyncio.sleep(retry_after)
-                    continue
+    started = time.monotonic()
+    try:
+        async with session.post(
+            url="https://openrouter.ai/api/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {os.getenv('OPENROUTER_KEY', '')}",
+                "HTTP-Referer": os.getenv(
+                    "SITE_URL", "https://github.com/transfaeries/faebot-twitch"
+                ),
+                "X-Title": "Faebot Twitch",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": model,
+                "messages": messages,
+                "temperature": params.get("temperature", TEMPERATURE),
+                "top_p": params.get("top_p", TOP_P),
+                # Answer budget plus the reasoning's own room on top.
+                "max_tokens": GENERATION_CAP + REASONING_CAP,
+                "reasoning": {"max_tokens": REASONING_CAP},
+            },
+            timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
+        ) as response:
+            elapsed = time.monotonic() - started
+            if response.status >= 400:
+                body = (await response.text())[:400]
+                raise GenerationFailed(
+                    f"OpenRouter returned {response.status}: {body}", elapsed
+                )
 
-                if response.status >= 400:
-                    body = await response.text()
-                    logging.error(f"OpenRouter returned {response.status}: {body}")
-                    return Completion(text=FALLBACK_TEXT, model=model)
+            result = await response.json()
+            elapsed = time.monotonic() - started
 
-                result = await response.json()
-                elapsed = time.monotonic() - started
-
-                if "choices" in result and len(result["choices"]) > 0:
-                    choice = result["choices"][0]
-                    message = choice.get("message") or {}
-                    return Completion(
-                        text=str(message.get("content") or ""),
-                        reasoning=str(message.get("reasoning") or ""),
-                        elapsed=elapsed,
-                        finish_reason=str(choice.get("finish_reason") or ""),
-                        model=str(result.get("model") or model),
-                        usage=result.get("usage") or {},
-                    )
-                else:
-                    logging.error(
-                        f"Unexpected response format from OpenRouter: {result}"
-                    )
-                    return Completion(text=FALLBACK_TEXT, model=model)
-
-        except (aiohttp.ClientError, ValueError, asyncio.TimeoutError) as e:
-            retry_after = min(2**attempt, 8)
-            logging.warning(
-                f"Network/parse error calling OpenRouter: {type(e).__name__}: {e}, "
-                f"retrying in {retry_after}s (attempt {attempt + 1}/{max_retries})"
+            try:
+                choice = result["choices"][0]
+            except (KeyError, IndexError, TypeError):
+                raise GenerationFailed(
+                    f"OpenRouter returned no choices: {str(result)[:200]}", elapsed
+                ) from None
+            message = choice.get("message") or {}
+            return Completion(
+                text=str(message.get("content") or ""),
+                reasoning=str(message.get("reasoning") or ""),
+                elapsed=elapsed,
+                finish_reason=str(choice.get("finish_reason") or ""),
+                model=str(result.get("model") or model),
+                provider=str(result.get("provider") or ""),
+                usage=result.get("usage") or {},
             )
-            await asyncio.sleep(retry_after)
-            continue
 
-    logging.error(f"OpenRouter API call failed after {max_retries} attempts")
-    raise Exception(f"OpenRouter API call failed after {max_retries} attempts")
+    except GenerationFailed:
+        raise
+    except asyncio.TimeoutError:
+        elapsed = time.monotonic() - started
+        raise GenerationFailed(
+            f"OpenRouter timed out after {elapsed:.0f}s (limit {REQUEST_TIMEOUT:.0f}s)",
+            elapsed,
+        ) from None
+    except (aiohttp.ClientError, ValueError) as error:
+        elapsed = time.monotonic() - started
+        raise GenerationFailed(
+            f"OpenRouter call failed: {type(error).__name__}: {error}", elapsed
+        ) from error

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ import logging
 import uvicorn
 import numpy as np
 import torch
+import core
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -107,8 +108,18 @@ def create_app(bot=None, events: asyncio.Queue | None = None):
         if model is None:
             raise RuntimeError("Whisper model not loaded")
         segments, info = model.transcribe(audio, initial_prompt=initial_prompt)
+        segments = list(segments)
         text = " ".join(segment.text for segment in segments).strip()
-        return text, info
+        # Whisper's own estimate that a segment is not speech — captured so
+        # the prompt-echo problem can be studied against real numbers.
+        no_speech_prob = (
+            max(
+                (getattr(segment, "no_speech_prob", 0.0) or 0.0) for segment in segments
+            )
+            if segments
+            else None
+        )
+        return text, info, no_speech_prob
 
     def _rebuild_executor():
         """Abandon a stuck executor thread and create a fresh one (keeps the model)."""
@@ -184,9 +195,6 @@ def create_app(bot=None, events: asyncio.Queue | None = None):
     async def audio_websocket(websocket: WebSocket) -> None:
         """WebSocket endpoint for receiving audio data and performing VAD."""
         initial_prompt = "faebot, transfaeries"
-        # Whisper sometimes echoes back substrings of the prompt instead of real speech.
-        # Substring check is intentional — catches partial echoes like "faebot" or "transfaeries".
-        prompt_echo_source = initial_prompt
         try:
             logging.debug("WebSocket handler entered")
             await websocket.accept()
@@ -263,7 +271,7 @@ def create_app(bot=None, events: asyncio.Queue | None = None):
 
                             try:
                                 loop = asyncio.get_event_loop()
-                                text, info = await asyncio.wait_for(
+                                text, info, no_speech_prob = await asyncio.wait_for(
                                     loop.run_in_executor(
                                         whisper_state["executor"],
                                         _transcribe_sync,
@@ -288,7 +296,7 @@ def create_app(bot=None, events: asyncio.Queue | None = None):
                                 speech_buffer = []
                                 continue
 
-                            if text and text.lower() not in prompt_echo_source:
+                            if not core.is_prompt_echo(text, initial_prompt):
                                 logging.debug(
                                     f"Transcription [{info.language}]: {text}"
                                 )
@@ -315,6 +323,7 @@ def create_app(bot=None, events: asyncio.Queue | None = None):
                                             info, "language_probability", None
                                         ),
                                         duration=duration,
+                                        no_speech_prob=no_speech_prob,
                                     )
                             else:
                                 logging.debug(f"Filtered prompt echo: {text}")

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -247,8 +247,10 @@ class AudioCapture {
 
 // EventStream: listens to /ws/events and renders generation cards.
 // Cards are correlated by generation_id — `generating` opens a card,
-// `response` fills it in, `error` marks it failed. Multiple in-flight
-// cards are fine; each closes independently.
+// `response` fills it in, `pass` marks it as chosen silence, `error` marks
+// it failed. Multiple in-flight cards are fine; each closes independently.
+// The reasoning channel (when the model has one) sits in a collapsed
+// <details> on the card — thoughts visible, words trusted.
 class EventStream {
     constructor() {
         this.log = document.getElementById('generationsLog');
@@ -298,6 +300,9 @@ class EventStream {
             case 'response':
                 this.fillCard(event);
                 break;
+            case 'pass':
+                this.passCard(event);
+                break;
             case 'error':
                 this.failCard(event);
                 break;
@@ -329,6 +334,10 @@ class EventStream {
             </div>
             <div class="gen-trigger"></div>
             <div class="gen-response"><span class="gen-pending">generating…</span></div>
+            <details class="gen-reasoning" hidden>
+                <summary>reasoning</summary>
+                <pre class="gen-reasoning-text"></pre>
+            </details>
             <div class="gen-details" hidden>
                 <h3>Trigger</h3>
                 <pre class="gen-trigger-full"></pre>
@@ -351,7 +360,9 @@ class EventStream {
         );
         card.querySelector('.gen-meta').textContent = `model: ${event.model || 'unknown'}`;
 
-        card.addEventListener('click', () => {
+        card.addEventListener('click', (click) => {
+            // The reasoning dropdown toggles itself; don't also toggle the card.
+            if (click.target.closest('.gen-reasoning')) return;
             const details = card.querySelector('.gen-details');
             details.hidden = !details.hidden;
         });
@@ -371,12 +382,40 @@ class EventStream {
         const card = entry.el;
         card.classList.remove('pending');
         card.querySelector('.gen-response').textContent = event.text || '';
-        // Update the meta line with timing if we have both timestamps
+        this.finishCard(card, entry, event);
+    }
+
+    passCard(event) {
+        const entry = this.cards.get(event.id);
+        if (!entry) {
+            console.debug('pass for unknown id:', event.id);
+            return;
+        }
+        const card = entry.el;
+        card.classList.remove('pending');
+        card.classList.add('passed');
+        const response = card.querySelector('.gen-response');
+        response.textContent = event.reason
+            ? `— stayed quiet: ${event.reason}`
+            : '— stayed quiet —';
+        this.finishCard(card, entry, event);
+    }
+
+    // Shared tail of response/pass: show the reasoning channel if there is
+    // one, and write the meta line (model · api time · finish reason).
+    finishCard(card, entry, event) {
+        if (event.reasoning) {
+            const reasoning = card.querySelector('.gen-reasoning');
+            reasoning.querySelector('.gen-reasoning-text').textContent = event.reasoning;
+            reasoning.hidden = false;
+        }
         const meta = card.querySelector('.gen-meta');
-        const startTs = entry.generating && entry.generating.timestamp;
-        if (meta && startTs && event.timestamp) {
-            const dt = (new Date(event.timestamp) - new Date(startTs)) / 1000;
-            meta.textContent = `model: ${entry.generating.model || 'unknown'} · ${dt.toFixed(2)}s`;
+        if (meta) {
+            const parts = [`model: ${event.model || (entry.generating && entry.generating.model) || 'unknown'}`];
+            if (typeof event.elapsed === 'number') parts.push(`${event.elapsed.toFixed(1)}s`);
+            if (event.finish_reason && event.finish_reason !== 'stop') parts.push(`finish: ${event.finish_reason}`);
+            if (event.attempts && event.attempts > 1) parts.push(`attempts: ${event.attempts}`);
+            meta.textContent = parts.join(' · ');
         }
         this.scrollToBottom();
     }

--- a/static/style.css
+++ b/static/style.css
@@ -259,6 +259,43 @@ header h1 {
     border-left-color: var(--color-error);
 }
 
+.gen-card.passed {
+    border-left-color: var(--color-secondary-dim);
+}
+
+.gen-card.passed .gen-response {
+    color: var(--color-secondary-dim);
+    font-style: italic;
+}
+
+/* The reasoning channel: a collapsed dropdown on the card. */
+.gen-reasoning {
+    margin-top: var(--space-sm);
+    font-size: 0.75rem;
+}
+
+.gen-reasoning[hidden] {
+    display: none;
+}
+
+.gen-reasoning summary {
+    color: var(--color-secondary-dim);
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.7rem;
+}
+
+.gen-reasoning pre {
+    margin-top: var(--space-sm);
+    background: var(--bg-surface);
+    padding: var(--space-sm);
+    border-radius: var(--radius);
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
 .gen-header {
     display: flex;
     gap: var(--space-sm);

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -226,10 +226,12 @@ class TestGenerateAndSend:
         assert event["reason"] == "they're busy"
 
     @pytest.mark.asyncio
-    async def test_generation_failure_emits_error_and_fallback(
+    async def test_generation_failure_posts_nothing_and_is_captured(
         self, mock_faebot, openrouter_error
     ):
-        """Generation failure should emit error event and send fallback message."""
+        """A machinery failure is not something faebot said: nothing goes to
+        chat (the old "Oops, something strange" fallback is gone); the error
+        event fires and the capture records `faebot_error`."""
         core.ensure_conversation("testchannel")
         openrouter_error(status=500, repeat=True)
 
@@ -237,20 +239,19 @@ class TestGenerateAndSend:
         mock_channel.send = AsyncMock()
         mock_faebot.get_channel = MagicMock(return_value=mock_channel)
 
-        await mock_faebot._generate_and_send("testchannel", trigger_type="chat")
+        with patch("bot.capture.record_faebot_error") as record_error:
+            await mock_faebot._generate_and_send("testchannel", trigger_type="chat")
 
-        # Check fallback message was sent
-        mock_channel.send.assert_called()
-        fallback_call = mock_channel.send.call_args
-        assert (
-            "oops" in fallback_call[0][0].lower()
-            or "strange" in fallback_call[0][0].lower()
-        )
+        mock_channel.send.assert_not_called()
+        record_error.assert_called_once()
+        args, meta = record_error.call_args
+        assert args[0] == "testchannel"
+        assert "500" in args[1]
+        assert meta["trigger_type"] == "chat"
+        assert "elapsed" in meta
 
-        # Check error event was emitted (skip the generating event)
         event = await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)
         assert event["type"] == "generating"
-
         event = await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)
         assert event["type"] == "error"
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -187,6 +187,45 @@ class TestGenerateAndSend:
         assert event["reasoning"] == "a greeting"
 
     @pytest.mark.asyncio
+    async def test_pass_sends_nothing_and_records_the_choice(
+        self, mock_faebot, mock_openrouter
+    ):
+        core.ensure_conversation("testchannel")
+        mock_openrouter.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            payload={
+                "choices": [
+                    {
+                        "message": {
+                            "content": "NOTHING-TO-SAY, they're busy",
+                            "reasoning": "ember is mid-sentence",
+                        }
+                    }
+                ]
+            },
+        )
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+        mock_faebot.get_channel = MagicMock(return_value=mock_channel)
+
+        with patch("bot.capture.record_faebot_pass") as record_pass, patch(
+            "bot.capture.record_faebot_message"
+        ) as record_message:
+            await mock_faebot._generate_and_send("testchannel", trigger_type="chat")
+
+        mock_channel.send.assert_not_called()
+        record_message.assert_not_called()
+        record_pass.assert_called_once()
+        args, meta = record_pass.call_args
+        assert args == ("testchannel", "they're busy")
+        assert meta["reasoning"] == "ember is mid-sentence"
+
+        await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)  # generating
+        event = await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)
+        assert event["type"] == "pass"
+        assert event["reason"] == "they're busy"
+
+    @pytest.mark.asyncio
     async def test_generation_failure_emits_error_and_fallback(
         self, mock_faebot, openrouter_error
     ):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -146,6 +146,47 @@ class TestGenerateAndSend:
         assert event["channel"] == "testchannel"
 
     @pytest.mark.asyncio
+    async def test_reasoning_reaches_capture_and_dashboard(
+        self, mock_faebot, mock_openrouter
+    ):
+        """The reasoning channel and the latency data ride along with the
+        utterance — into the capture (for memory faebot) and the response
+        event (for the dashboard) — while chat gets only the answer."""
+        core.ensure_conversation("testchannel")
+        mock_openrouter.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            payload={
+                "model": "moonshotai/kimi-k3",
+                "choices": [
+                    {
+                        "message": {"content": "hi!", "reasoning": "a greeting"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+        mock_faebot.get_channel = MagicMock(return_value=mock_channel)
+
+        with patch("bot.capture.record_faebot_message") as record:
+            await mock_faebot._generate_and_send("testchannel", trigger_type="chat")
+
+        mock_channel.send.assert_called_once_with("hi!")
+        record.assert_called_once()
+        meta = record.call_args.kwargs
+        assert meta["reasoning"] == "a greeting"
+        assert meta["finish_reason"] == "stop"
+        assert meta["model"] == "moonshotai/kimi-k3"
+        assert "elapsed" in meta
+
+        await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)  # generating
+        event = await asyncio.wait_for(mock_faebot.event_queue.get(), timeout=1.0)
+        assert event["type"] == "response"
+        assert event["text"] == "hi!"
+        assert event["reasoning"] == "a greeting"
+
+    @pytest.mark.asyncio
     async def test_generation_failure_emits_error_and_fallback(
         self, mock_faebot, openrouter_error
     ):

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -102,6 +102,18 @@ class TestFaithfulRecording:
         assert event["elapsed"] == 4.2
         assert event["generation_id"] == "g1"
 
+    def test_record_faebot_error_is_its_own_kind(self, enabled):
+        capture.record_faebot_error(
+            "transfaeries",
+            "GenerationFailed: timed out",
+            generation_id="g2",
+            elapsed=90.2,
+        )
+        (event,) = read_events(enabled)
+        assert event["kind"] == "faebot_error"
+        assert event["error"] == "GenerationFailed: timed out"
+        assert event["elapsed"] == 90.2
+
     def test_raw_skips_only_keepalives(self, enabled):
         capture.record_raw(
             "PING :tmi.twitch.tv\r\n:ronni!ronni@ronni.tmi.twitch.tv JOIN #dallas\r\nPONG"

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -87,6 +87,21 @@ class TestFaithfulRecording:
         assert event["language"] == "en"
         assert event["duration"] == 2.5
 
+    def test_record_faebot_pass_keeps_reason_and_reasoning(self, enabled):
+        capture.record_faebot_pass(
+            "transfaeries",
+            "they're mid-conversation",
+            generation_id="g1",
+            reasoning="ember is talking to minou",
+            elapsed=4.2,
+        )
+        (event,) = read_events(enabled)
+        assert event["kind"] == "faebot_pass"
+        assert event["reason"] == "they're mid-conversation"
+        assert event["reasoning"] == "ember is talking to minou"
+        assert event["elapsed"] == 4.2
+        assert event["generation_id"] == "g1"
+
     def test_raw_skips_only_keepalives(self, enabled):
         capture.record_raw(
             "PING :tmi.twitch.tv\r\n:ronni!ronni@ronni.tmi.twitch.tv JOIN #dallas\r\nPONG"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -199,21 +199,22 @@ class TestGenerate:
         await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_non_retryable_error_returns_fallback(self):
+    async def test_4xx_raises_generation_failed(self):
+        """No fallback text is returned (it used to be POSTED to chat)."""
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 status=403,
                 payload={"error": "forbidden"},
             )
-            result = await core.generate(prompt="hello")
-            assert "couldn't generate" in result.text.lower()
+            with pytest.raises(core.GenerationFailed, match="403"):
+                await core.generate(prompt="hello")
             await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_retries_on_500_then_succeeds(self):
+    async def test_5xx_raises_without_retrying(self):
+        """One request, one chance: a 500 is a failure, not a retry loop."""
         with aioresponses_ctx() as mocked:
-            # First call: 500, second call: success
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 status=500,
@@ -221,45 +222,97 @@ class TestGenerate:
             )
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
-                payload={"choices": [{"message": {"content": "recovered!"}}]},
+                payload={"choices": [{"message": {"content": "never reached"}}]},
             )
-            result = await core.generate(prompt="hello")
-            assert result.text == "recovered!"
+            with pytest.raises(core.GenerationFailed, match="500"):
+                await core.generate(prompt="hello")
+            calls = sum(len(c) for c in mocked.requests.values())
+            assert calls == 1
             await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_retries_on_429_rate_limit(self):
+    async def test_429_raises_without_retrying(self):
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 status=429,
                 payload={"error": "rate limited"},
             )
-            mocked.post(
-                "https://openrouter.ai/api/v1/chat/completions",
-                payload={"choices": [{"message": {"content": "after rate limit"}}]},
-            )
-            result = await core.generate(prompt="hello")
-            assert result.text == "after rate limit"
+            with pytest.raises(core.GenerationFailed, match="429"):
+                await core.generate(prompt="hello")
             await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_all_retries_exhausted_raises(self, openrouter_error):
+    async def test_network_error_raises_generation_failed(self, openrouter_error):
         openrouter_error(status=500, repeat=True)
-        with pytest.raises(Exception, match="failed after 3 attempts"):
+        with pytest.raises(core.GenerationFailed):
             await core.generate(prompt="hello")
         await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_malformed_response_returns_fallback(self):
+    async def test_timeout_raises_generation_failed_with_elapsed(self):
+        import asyncio as _asyncio
+
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                exception=_asyncio.TimeoutError(),
+            )
+            with pytest.raises(core.GenerationFailed, match="timed out") as info:
+                await core.generate(prompt="hello")
+            assert info.value.elapsed >= 0
+            await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(self):
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 payload={"unexpected": "format"},
             )
-            result = await core.generate(prompt="hello")
-            assert "couldn't generate" in result.text.lower()
+            with pytest.raises(core.GenerationFailed, match="no choices"):
+                await core.generate(prompt="hello")
             await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_request_carries_pinned_sampling_and_timeout(self):
+        """Sampling is pinned (no lottery, no top_k, no seed) and every
+        request has a real timeout."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "ok"}}]},
+            )
+            await core.generate(
+                prompt="hello", params={"temperature": 1.0, "top_p": 0.95}
+            )
+            (request,) = [call for calls in mocked.requests.values() for call in calls]
+        body = request.kwargs["json"]
+        assert body["temperature"] == 1.0
+        assert body["top_p"] == 0.95
+        assert "top_k" not in body and "seed" not in body
+        timeout = request.kwargs["timeout"]
+        assert timeout.total == core.REQUEST_TIMEOUT
+        await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_provider_and_params_ride_on_the_completion(self):
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={
+                    "provider": "Moonshot AI",
+                    "choices": [{"message": {"content": "ok"}}],
+                },
+            )
+            result = await core.generate(
+                prompt="hello", params={"temperature": 0.7, "top_p": 0.9}
+            )
+        assert result.provider == "Moonshot AI"
+        assert result.params == {"temperature": 0.7, "top_p": 0.9}
+        assert result.capture_meta()["provider"] == "Moonshot AI"
+        assert result.capture_meta()["params"] == {"temperature": 0.7, "top_p": 0.9}
+        await core.close_session()
 
     @pytest.mark.asyncio
     async def test_reasoning_and_content_kept_apart(self):
@@ -498,6 +551,10 @@ class TestEventQueue:
         assert events[0]["model"] == conversation.model
         assert "prompt" in events[0]
         assert "system_prompt" in events[0]
+        assert events[0]["params"] == {
+            "temperature": core.TEMPERATURE,
+            "top_p": core.TOP_P,
+        }
         await core.close_session()
 
     @pytest.mark.asyncio
@@ -510,7 +567,7 @@ class TestEventQueue:
                 payload={"error": "server error"},
                 repeat=True,
             )
-            with pytest.raises(Exception, match="failed after 3 attempts"):
+            with pytest.raises(core.GenerationFailed):
                 await core.generate_response("testchannel", events=queue)
         events = _drain_queue(queue)
         types = [e["type"] for e in events]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -410,6 +410,10 @@ class TestGenerate:
         assert body["model"] == "some/model"
         assert body["reasoning"] == {"max_tokens": core.REASONING_CAP}
         assert body["max_tokens"] == core.GENERATION_CAP + core.REASONING_CAP
+        assert body["provider"] == {
+            "order": list(core.PROVIDERS),
+            "allow_fallbacks": False,
+        }
         await core.close_session()
 
     @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -159,6 +159,44 @@ class TestBuildSystemPrompt:
         assert core.history_floor(limit) == floor
 
 
+# ── the whisper prompt echo ──────────────────────────────────────────
+
+
+class TestIsPromptEcho:
+    PROMPT = "faebot, transfaeries"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "faebot, transfaeries",
+            "faebot, transfaeries  faebot, transfaeries",
+            "Faebot.",
+            "faebot!",
+            "and faebot, transfaeries",
+            "the faebot transfaeries",
+            "",
+            "...",
+        ],
+    )
+    def test_echoes(self, text):
+        assert core.is_prompt_echo(text, self.PROMPT)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "hello faebot, can you hear me?",
+            "faebot dearest",
+            "thank you faebot",
+            "I love speedruns, faebot",
+            "and guess who else is back, faebot is back",
+            "we heal at least",
+            "ようこそ",  # another script is not an echo (a different question)
+        ],
+    )
+    def test_real_speech(self, text):
+        assert not core.is_prompt_echo(text, self.PROMPT)
+
+
 # ── the silence sentinel ─────────────────────────────────────────────
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -311,8 +311,54 @@ class TestGenerate:
             await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_504_does_not_retry(self):
-        """Only 429 retries; an upstream abort (OpenRouter's 504) is final."""
+    async def test_504_retries_once_on_the_rest_of_the_pinned_list(self, monkeypatch):
+        """An upstream drop is retried ONCE, aimed at the pinned providers
+        after the one that dropped — never outside the pin."""
+        monkeypatch.setattr(core, "PROVIDERS", ("moonshotai", "modal"))
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=504,
+                payload={"error": {"message": "The operation was aborted"}},
+            )
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "caught by modal"}}]},
+            )
+            result = await core.generate(prompt="hello")
+            assert result.text == "caught by modal"
+            sent = [
+                c.kwargs["json"] for calls in mocked.requests.values() for c in calls
+            ]
+            assert len(sent) == 2
+            assert sent[0]["provider"]["order"] == ["moonshotai", "modal"]
+            assert sent[1]["provider"] == {"order": ["modal"], "allow_fallbacks": False}
+            await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_504_inside_a_200_body_counts_as_a_drop(self, monkeypatch):
+        """OpenRouter answers 200 with `{"error": {"code": 504}}` when the
+        upstream aborts mid-call; that is the drop we actually see."""
+        monkeypatch.setattr(core, "PROVIDERS", ("moonshotai", "modal"))
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={
+                    "error": {"message": "The operation was aborted", "code": 504}
+                },
+            )
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "caught by modal"}}]},
+            )
+            result = await core.generate(prompt="hello")
+            assert result.text == "caught by modal"
+            await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_504_with_nowhere_else_to_go_is_final(self, monkeypatch):
+        """One pinned provider: a drop has no second address, so it fails."""
+        monkeypatch.setattr(core, "PROVIDERS", ("moonshotai",))
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
@@ -325,7 +371,7 @@ class TestGenerate:
             )
             with pytest.raises(core.GenerationFailed, match="504") as info:
                 await core.generate(prompt="hello")
-            assert not info.value.is_rate_limit
+            assert info.value.is_upstream_drop and not info.value.is_rate_limit
             calls = sum(len(c) for c in mocked.requests.values())
             assert calls == 1
             await core.close_session()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -231,15 +231,61 @@ class TestGenerate:
             await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_429_raises_without_retrying(self):
+    async def test_429_gets_exactly_one_immediate_retry(self, monkeypatch):
+        """A shared-pool rate limit clears in a second: one retry, on 429
+        only, then it's a failure like any other."""
+        monkeypatch.setattr(core, "RATE_LIMIT_RETRY_DELAY", 0)
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 status=429,
                 payload={"error": "rate limited"},
             )
-            with pytest.raises(core.GenerationFailed, match="429"):
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "recovered"}}]},
+            )
+            result = await core.generate(prompt="hello")
+            assert result.text == "recovered"
+            calls = sum(len(c) for c in mocked.requests.values())
+            assert calls == 2
+            await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_429_twice_fails_after_the_one_retry(self, monkeypatch):
+        monkeypatch.setattr(core, "RATE_LIMIT_RETRY_DELAY", 0)
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=429,
+                payload={"error": "rate limited"},
+                repeat=True,
+            )
+            with pytest.raises(core.GenerationFailed, match="429") as info:
                 await core.generate(prompt="hello")
+            assert info.value.is_rate_limit
+            calls = sum(len(c) for c in mocked.requests.values())
+            assert calls == 2
+            await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_504_does_not_retry(self):
+        """Only 429 retries; an upstream abort (OpenRouter's 504) is final."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=504,
+                payload={"error": {"message": "The operation was aborted"}},
+            )
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "never reached"}}]},
+            )
+            with pytest.raises(core.GenerationFailed, match="504") as info:
+                await core.generate(prompt="hello")
+            assert not info.value.is_rate_limit
+            calls = sum(len(c) for c in mocked.requests.values())
+            assert calls == 1
             await core.close_session()
 
     @pytest.mark.asyncio
@@ -261,6 +307,9 @@ class TestGenerate:
             with pytest.raises(core.GenerationFailed, match="timed out") as info:
                 await core.generate(prompt="hello")
             assert info.value.elapsed >= 0
+            assert not info.value.is_rate_limit
+            calls = sum(len(c) for c in mocked.requests.values())
+            assert calls == 1
             await core.close_session()
 
     @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -273,10 +273,14 @@ class TestGenerate:
             await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_429_gets_exactly_one_immediate_retry(self, monkeypatch):
-        """A shared-pool rate limit clears in a second: one retry, on 429
-        only, then it's a failure like any other."""
+    async def test_429_gets_exactly_one_retry_aimed_past_the_pool_that_said_no(
+        self, monkeypatch
+    ):
+        """A shared-pool rate limit clears in a second — but the pool that
+        said no is the one a same-list retry asks again (five asks lost that
+        way on 08-27). One retry, aimed at the rest of the pinned list."""
         monkeypatch.setattr(core, "RATE_LIMIT_RETRY_DELAY", 0)
+        monkeypatch.setattr(core, "PROVIDERS", ("moonshotai", "modal"))
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
@@ -289,8 +293,36 @@ class TestGenerate:
             )
             result = await core.generate(prompt="hello")
             assert result.text == "recovered"
-            calls = sum(len(c) for c in mocked.requests.values())
-            assert calls == 2
+            sent = [
+                c.kwargs["json"] for calls in mocked.requests.values() for c in calls
+            ]
+            assert len(sent) == 2
+            assert sent[0]["provider"]["order"] == ["moonshotai", "modal"]
+            assert sent[1]["provider"] == {"order": ["modal"], "allow_fallbacks": False}
+            await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_429_with_one_pinned_provider_still_retries_it(self, monkeypatch):
+        """Nowhere else to aim: the one retry asks the same provider again,
+        as it always did."""
+        monkeypatch.setattr(core, "RATE_LIMIT_RETRY_DELAY", 0)
+        monkeypatch.setattr(core, "PROVIDERS", ("moonshotai",))
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=429,
+                payload={"error": "rate limited"},
+            )
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "recovered"}}]},
+            )
+            result = await core.generate(prompt="hello")
+            assert result.text == "recovered"
+            sent = [
+                c.kwargs["json"] for calls in mocked.requests.values() for c in calls
+            ]
+            assert [s["provider"]["order"] for s in sent] == [["moonshotai"]] * 2
             await core.close_session()
 
     @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,10 +25,12 @@ class TestEnsureConversation:
         assert second.frequency == 0.99
 
     def test_defaults(self):
+        """Defaults come from the env-readable module constants."""
         conv = core.ensure_conversation("defaults")
-        assert conv.frequency == 0.05
-        assert conv.voice_frequency == 0.025
-        assert conv.history == 20
+        assert conv.frequency == core.FREQUENCY
+        assert conv.voice_frequency == core.VOICE_FREQUENCY
+        assert conv.history == core.HISTORY
+        assert conv.model == core.MODEL
         assert conv.silenced is False
         assert conv.chatlog == []
 
@@ -161,7 +163,9 @@ class TestGenerate:
     async def test_successful_generation(self, openrouter_success):
         openrouter_success("test response")
         result = await core.generate(prompt="hello", system_prompt="you are faebot")
-        assert result == "test response"
+        assert result.text == "test response"
+        assert result.reasoning == ""
+        assert result.attempts == 1
         await core.close_session()
 
     @pytest.mark.asyncio
@@ -173,7 +177,7 @@ class TestGenerate:
                 payload={"error": "forbidden"},
             )
             result = await core.generate(prompt="hello")
-            assert "couldn't generate" in result.lower()
+            assert "couldn't generate" in result.text.lower()
             await core.close_session()
 
     @pytest.mark.asyncio
@@ -190,7 +194,7 @@ class TestGenerate:
                 payload={"choices": [{"message": {"content": "recovered!"}}]},
             )
             result = await core.generate(prompt="hello")
-            assert result == "recovered!"
+            assert result.text == "recovered!"
             await core.close_session()
 
     @pytest.mark.asyncio
@@ -206,7 +210,7 @@ class TestGenerate:
                 payload={"choices": [{"message": {"content": "after rate limit"}}]},
             )
             result = await core.generate(prompt="hello")
-            assert result == "after rate limit"
+            assert result.text == "after rate limit"
             await core.close_session()
 
     @pytest.mark.asyncio
@@ -224,8 +228,90 @@ class TestGenerate:
                 payload={"unexpected": "format"},
             )
             result = await core.generate(prompt="hello")
-            assert "couldn't generate" in result.lower()
+            assert "couldn't generate" in result.text.lower()
             await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_and_content_kept_apart(self):
+        """`content` is the answer channel, `reasoning` a separate one — both
+        survive, neither leaks into the other."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={
+                    "model": "moonshotai/kimi-k3",
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "hi chat!",
+                                "reasoning": "they said hello, I should say hi",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"completion_tokens": 40},
+                },
+            )
+            result = await core.generate(prompt="hello")
+        assert result.text == "hi chat!"
+        assert result.reasoning == "they said hello, I should say hi"
+        assert result.finish_reason == "stop"
+        assert result.model == "moonshotai/kimi-k3"
+        assert result.usage == {"completion_tokens": 40}
+        assert result.elapsed >= 0
+        await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_request_sends_reasoning_room_on_top_of_answer_cap(self):
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "ok"}}]},
+            )
+            await core.generate(prompt="hello", model="some/model")
+            (request,) = [call for calls in mocked.requests.values() for call in calls]
+        body = request.kwargs["json"]
+        assert body["model"] == "some/model"
+        assert body["reasoning"] == {"max_tokens": core.REASONING_CAP}
+        assert body["max_tokens"] == core.GENERATION_CAP + core.REASONING_CAP
+        await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_empty_answer_channel_rolls_again(self):
+        """Empty `content` beside a full `reasoning` is a dropped payload, not
+        silence — roll once more."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={
+                    "choices": [
+                        {"message": {"content": "", "reasoning": "thinking..."}}
+                    ]
+                },
+            )
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": "second try"}}]},
+            )
+            result = await core.generate(prompt="hello")
+        assert result.text == "second try"
+        assert result.attempts == 2
+        await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_empty_twice_returns_empty_honestly(self):
+        """After the rolls run out the Completion stays empty — the caller
+        decides what a dropped payload means; generate() tells the truth."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={"choices": [{"message": {"content": ""}}]},
+                repeat=True,
+            )
+            result = await core.generate(prompt="hello")
+        assert result.is_empty
+        assert result.attempts == core.EMPTY_ROLLS
+        await core.close_session()
 
 
 # ── generate_response (full pipeline) ────────────────────────────────
@@ -243,7 +329,7 @@ class TestGenerateResponse:
             result = await core.generate_response(
                 "testchannel", stream_title="Test", game_name="Art"
             )
-        assert result == "hi there!"
+        assert result.text == "hi there!"
         assert "faebot: hi there!" in conversation.chatlog
         await core.close_session()
 
@@ -270,8 +356,24 @@ class TestGenerateResponse:
                 payload={"choices": [{"message": {"content": long_text}}]},
             )
             result = await core.generate_response("testchannel")
-        assert len(result) == 500
-        assert result.endswith("\u2013")
+        assert len(result.text) == 500
+        assert result.text.endswith("\u2013")
+        await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_multiline_reply_is_folded_to_one_line(self, conversation):
+        """IRC carries one line per message; kimi writes several."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={
+                    "choices": [
+                        {"message": {"content": "hi chat!!\n\n*flutters*  \nbye~"}}
+                    ]
+                },
+            )
+            result = await core.generate_response("testchannel")
+        assert result.text == "hi chat!! *flutters* bye~"
         await core.close_session()
 
     @pytest.mark.asyncio
@@ -283,7 +385,7 @@ class TestGenerateResponse:
                 payload={"choices": [{"message": {"content": "hitransf23Botlovebye"}}]},
             )
             result = await core.generate_response("testchannel", emotes=emotes)
-        assert result == "hi transf23Botlove bye"
+        assert result.text == "hi transf23Botlove bye"
         await core.close_session()
 
     @pytest.mark.asyncio
@@ -319,7 +421,7 @@ class TestEventQueue:
                 payload={"choices": [{"message": {"content": "hi"}}]},
             )
             result = await core.generate_response("testchannel")
-        assert result == "hi"
+        assert result.text == "hi"
         await core.close_session()
 
     @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -155,6 +155,36 @@ class TestBuildSystemPrompt:
         assert "42" in prompt
 
 
+# ── the silence sentinel ─────────────────────────────────────────────
+
+
+class TestSaidNothing:
+    def test_bare_sentinel(self):
+        assert core.said_nothing("NOTHING-TO-SAY")
+        assert core.pass_reason("NOTHING-TO-SAY") == ""
+
+    def test_case_and_spacing_are_forgiven(self):
+        assert core.said_nothing("nothing to say")
+        assert core.said_nothing("  Nothing-To-Say.")
+
+    def test_reason_after_sentinel_is_kept(self):
+        text = "NOTHING-TO-SAY — they're mid-conversation, I'll listen"
+        assert core.said_nothing(text)
+        assert core.pass_reason(text) == "they're mid-conversation, I'll listen"
+
+    def test_sentinel_mid_sentence_is_speech(self):
+        assert not core.said_nothing("honestly I have nothing to say about that")
+
+    def test_empty_is_a_drop_not_silence(self):
+        assert not core.said_nothing("")
+        assert not core.said_nothing("   ")
+
+    def test_prompt_tells_faebot_the_verb(self):
+        conv = core.Conversation(channel="c")
+        prompt = core.build_system_prompt(conv, "c", "t", "g", [])
+        assert core.SENTINEL_SILENCE in prompt
+
+
 # ── generate (OpenRouter API) ────────────────────────────────────────
 
 
@@ -358,6 +388,32 @@ class TestGenerateResponse:
             result = await core.generate_response("testchannel")
         assert len(result.text) == 500
         assert result.text.endswith("\u2013")
+        await core.close_session()
+
+    @pytest.mark.asyncio
+    async def test_pass_is_not_posted_but_is_remembered(self, conversation):
+        """The sentinel marks chosen silence: text stays as-is for the caller
+        to recognise, the chatlog records the fact (not the reason)."""
+        with aioresponses_ctx() as mocked:
+            mocked.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload={
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "NOTHING-TO-SAY — just listening",
+                                "reasoning": "nobody's talking to me",
+                            }
+                        }
+                    ]
+                },
+            )
+            result = await core.generate_response("testchannel")
+        assert result.passed
+        assert result.reason_for_passing == "just listening"
+        assert result.reasoning == "nobody's talking to me"
+        assert conversation.chatlog[-1] == "faebot: *stays quiet*"
+        assert not any("listening" in line for line in conversation.chatlog)
         await core.close_session()
 
     @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -152,7 +152,11 @@ class TestBuildSystemPrompt:
         prompt = core.build_system_prompt(
             conversation, "testchannel", "Title", "Game", []
         )
-        assert "42" in prompt
+        assert "between the last 34 and 42 messages" in prompt
+
+    @pytest.mark.parametrize("limit,floor", [(50, 40), (10, 8), (4, 4)])
+    def test_history_floor_drops_a_fifth(self, limit, floor):
+        assert core.history_floor(limit) == floor
 
 
 # ── the silence sentinel ─────────────────────────────────────────────
@@ -466,17 +470,20 @@ class TestGenerateResponse:
         await core.close_session()
 
     @pytest.mark.asyncio
-    async def test_trims_chatlog_to_history_length(self, conversation):
-        conversation.history = 5
-        conversation.chatlog = [f"msg{i}" for i in range(10)]
+    async def test_trims_chatlog_in_a_block(self, conversation):
+        """Over the limit → cut back to the floor (10 - 10//5 = 8), so the
+        prompt prefix stays put for the next couple of calls."""
+        conversation.history = 10
+        conversation.chatlog = [f"msg{i}" for i in range(20)]
         with aioresponses_ctx() as mocked:
             mocked.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 payload={"choices": [{"message": {"content": "reply"}}]},
             )
             await core.generate_response("testchannel")
-        # 5 kept from trim + 1 appended response
-        assert len(conversation.chatlog) == 6
+        # 8 kept from trim + 1 appended response
+        assert len(conversation.chatlog) == 9
+        assert conversation.chatlog[0] == "msg12"
         await core.close_session()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
# The reasoning channel, kimi-k3, and silence as a verb

Built 2026-08-19, the afternoon before the stream; **ran live that evening**
(deployed to faehome by branch pull — this PR is the state marker for that
deploy, opened the morning after).

## What this is

The kimi-on-the-fly bug (switching models live posted `None`) was the
reasoning-channel family: a reasoning model answers into `reasoning` and
leaves `content` empty, and the parser only read `content`. The ruling
(faebot-private core-roadmap, Now-1 session two) was to **enable reasoning as
its own channel rather than suppress it**. Three commits:

1. **`generation: the reasoning channel, kimi-k3 by default, caps as safety
   nets`** — `generate()` returns a `Completion` (text + reasoning + elapsed
   + finish_reason + model + usage + attempts; same shape as faebot-core's)
   instead of a bare string. Content and reasoning are kept apart: text to
   chat, reasoning to the capture + dashboard. Caps are env-readable
   (`GENERATION_CAP=500`, `REASONING_CAP=8000`) and are *safety nets, not
   instructions* — the model can't see its own budget; length is the
   prompt's job. Reasoning room rides ON TOP of the answer budget (core's
   lesson). Empty answer channel = dropped payload → one re-roll. `HISTORY`
   (50), `FREQUENCY`, `VOICE_FREQUENCY` become env-readable startup
   defaults. Multi-line replies fold to one IRC line.

2. **`silence is a verb: NOTHING-TO-SAY, and the prompt that offers it`** —
   a reply starting with the sentinel (same coined-hyphenated grammar as
   core's NOTHING-TO-RECORD) posts nothing; the chatlog records
   `faebot: *stays quiet*`; the reason after the sentinel is kept. New
   capture kind `faebot_pass`. The system prompt tells faebot the verb
   exists, in faer voice.

3. **`dashboard: the reasoning dropdown, and passes as cards`** — collapsed
   "reasoning" `<details>` per card; `pass` events close their card as
   chosen silence; meta line shows model · api seconds · finish reason ·
   attempts.

## Verified live — the 2026-08-19 stream (capture `twitch-20260819.jsonl`)

- **91 faebot messages, all kimi-k3, all with full meta.** Zero `None`
  posts, zero trims, zero empty-channel re-rolls, all `finish_reason=stop`.
- **Latency:** min 1.7s / median 9.8s / p90 26.8s / max 41.7s. Tracks
  reasoning length mostly (slowest gens carried 4–7k chars of thought);
  some pure provider variance.
- **Reasoning:** median 1223 chars, max 1862 tokens — the 8000 cap never
  came close to firing.
- **The pass verb was used 0 times but explicitly *considered* 7 times** in
  reasoning ("the bit might be done... I think NOTHING-TO-SAY is
  reasonable"), including self-regulation against faer own reply frequency.
  The frequency roll already filters asks down to moments worth speaking
  in, so the two silence mechanisms stack.
- Cost: $1.04 for the stream (~1.1¢/message).

## Known-not-done

- The dashboard JS has no test harness (node-parse + live use only).
- The pass verb wording may want tuning — the one pre-stream invited pass
  came back as an *announcement* of quietness rather than the sentinel.
  Left as-is deliberately; watching captures.
- discord has the same reasoning-channel root bug — same fix wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 08-29 — the 429 re-aim (`fe8c875`)

The 08-27 stream (short, Twitch outage) stream-proved the drop retry once (28 messages, 27 Moonshot + 1 Modal) **but lost five asks to Moonshot's shared-pool 429**: the one retry waited a second and asked the same list — on a saturated night, the same pool. Now a 429 takes the drop retry's aim: `PROVIDERS[1:]` when there is one, the same provider when there isn't (as before). Also found: `_generate_once`'s default `providers=PROVIDERS` was bound at import, so a re-pinned list never reached the first call in tests; the driver passes it explicitly now. Gate green, 151 tests.

**Not stream-proven** — fae is away from Tuesday 09-01 for two weeks, no streams. Merges on review; the first stream back is the live test, and the deploy comment will say so.

**Second review (kimi-k3, signing "Vesper"):** no must-fix; policy parity with discord confirmed; the import-bound default fully fixed at both call sites; single-pin behaviour traced and matches the tests. Nit left: the inert `providers=PROVIDERS` default on `_generate_once` — retire when next touched. Review file: faebot-private `scratch/reviews/pr17-31-review.md`.
